### PR TITLE
[WIP] Add Typed Workflow State

### DIFF
--- a/src/workflows/context/state_manager.py
+++ b/src/workflows/context/state_manager.py
@@ -20,7 +20,7 @@ class InMemoryStateManager(Generic[T]):
     
     class MyWorkflow(Workflow):
         @step
-        async def step_1(self, ctx: Context[MyState], ev: StartEvent) -> StopEvent:
+        async def step_1(self, ctx: Annotated[Context, MyState], ev: StartEvent) -> StopEvent:
             state = await ctx.state.get()
             state.name = "John"
             state.age = 30


### PR DESCRIPTION
Currently, the `Context` provides an async and untyped get/set API

Pros:
- easy to use
- always there
- async, so maybe someday it can be easily backed by some DB

Cons:
- untyped
- serialization nightmare

This PR introduces a concept of a state manager. The idea is to capture the same pros as the current workflow state, but also fix the cons.

This API would be opt-in. My current thinking is to use type annotations to set the state class. 

```
class MyState(BaseModel):
        name: str
        age: int
    
class MyWorkflow(Workflow):
    @step
    async def step_1(self, ctx: Annotated[Context, MyState], ev: StartEvent) -> StopEvent:
        state = await ctx.state.get()
        state.name = "John"
        state.age = 30
        await ctx.state.set(state)

        return StopEvent()
```

Pros:
- opt-in / non-breaking
- async
- type safe
- allows for partial access of fields (i.e. `state.get_path("some.nested.field")`) -- this loses type safety but is DB friendly
- user controls serialization (because its a pydantic class)

Cons:
- Not sure how to make this singleton per workflow.run()
- What if the user annotates two steps in a workflow with different pydantic state models?