### PR TITLE
fix: do not count testing code for coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
   "pydantic>=2.11.5"
 ]
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/workflows"]
-
 [tool.coverage.run]
 omit = ["tests/*"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/workflows"]


### PR DESCRIPTION
We are including the source code under `tests/` in the test coverage, making the metric not accurate and the report harder to read.