### PR TITLE
properly move and support clear method

### DIFF
--- a/src/workflows/context/context.py
+++ b/src/workflows/context/context.py
@@ -552,11 +552,11 @@ class Context(Generic[MODEL_T]):
     def clear(self) -> None:
         """Clear any data stored in the context.
 
-        DEPRECATED: Use `await ctx.store.set(StateCLS())` instead.
+        DEPRECATED: Use `await ctx.store.clear()` instead.
         This method is deprecated and will be removed in a future version.
         """
         warnings.warn(
-            "Context.clear() is deprecated. Use 'await ctx.store.set(StateCLS())' instead.",
+            "Context.clear() is deprecated. Use 'await ctx.store.clear()' instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -652,7 +652,9 @@ class Context(Generic[MODEL_T]):
                         await self._init_state_store(state_instance)
                     except Exception as e:
                         raise WorkflowRuntimeError(
-                            f"Failed to initialize state of type {config.context_state_type}: {e}"
+                            f"Failed to initialize state of type {config.context_state_type}. "
+                            "Does your state define defaults for all fields? Original error:\n"
+                            f"{e}"
                         ) from e
                 else:
                     # Initialize state manager with DictState by default

--- a/src/workflows/context/state_store.py
+++ b/src/workflows/context/state_store.py
@@ -1,7 +1,7 @@
 import asyncio
 import warnings
 from contextlib import asynccontextmanager
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing import Any, AsyncGenerator, Generic, Optional, TypeVar
 
 from workflows.events import Event
@@ -244,6 +244,14 @@ class InMemoryStateStore(Generic[MODEL_T]):
 
             # Assign the final value
             self._assign_step(current, segments[-1], value)
+
+    async def clear(self) -> None:
+        """Clear the state."""
+        async with self._lock:
+            try:
+                self._state = self._state.__class__()
+            except ValidationError:
+                raise ValueError("State must have defaults for all fields")
 
     def _traverse_step(self, obj: Any, segment: str) -> Any:
         """Follow one segment into *obj* (dict key, list index, or attribute)."""

--- a/src/workflows/context/state_store.py
+++ b/src/workflows/context/state_store.py
@@ -247,11 +247,10 @@ class InMemoryStateStore(Generic[MODEL_T]):
 
     async def clear(self) -> None:
         """Clear the state."""
-        async with self._lock:
-            try:
-                self._state = self._state.__class__()
-            except ValidationError:
-                raise ValueError("State must have defaults for all fields")
+        try:
+            await self.set_state(self._state.__class__())
+        except ValidationError:
+            raise ValueError("State must have defaults for all fields")
 
     def _traverse_step(self, obj: Any, segment: str) -> Any:
         """Follow one segment into *obj* (dict key, list index, or attribute)."""

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -168,3 +168,14 @@ async def test_state_manager_custom_serialization(
 
     state = await new_state_manager.get_state()
     assert state.pydantic_obj.name == "llama-index"
+
+
+@pytest.mark.asyncio
+async def test_state_manager_clear() -> None:
+    state_manager = InMemoryStateStore(DictState())
+    await state_manager.set("name", "Jane")
+    await state_manager.set("age", 25)
+
+    await state_manager.clear()
+    assert await state_manager.get("name", default=None) is None
+    assert await state_manager.get("age", default=None) is None


### PR DESCRIPTION
Fixes https://github.com/run-llama/workflows-py/issues/27

We deprecated the old `clear()` method, but
a) provided no (easy) alternative
b) had incorrect docstrings and deprecation warnings pointing to the wrong methods

I also updated some errors slightly, to better reflect issues when your state cls does not have default fields (I ran into this when writing the test)