### PR TITLE
Add default type to generic state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ requires-python = ">=3.9"
 dependencies = [
   "eval-type-backport>=0.2.2 ; python_full_version < '3.10'",
   "llama-index-instrumentation>=0.1.0",
-  "pydantic>=2.11.5"
+  "pydantic>=2.11.5",
+  "typing-extensions>=4.6.0"
 ]
 
 [project.optional-dependencies]

--- a/src/workflows/context/state_store.py
+++ b/src/workflows/context/state_store.py
@@ -1,16 +1,16 @@
 import asyncio
 import warnings
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Generic, Optional, TypeVar
+from typing import Any, AsyncGenerator, Generic, Optional
 
 from pydantic import BaseModel, ValidationError
+from typing_extensions import TypeVar
 
 from workflows.events import DictLikeModel
 
 from .serializers import BaseSerializer
 
 MAX_DEPTH = 1000
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel)
 
 
 # Only warn once about unserializable keys
@@ -31,6 +31,10 @@ class DictState(DictLikeModel):
 
     def __init__(self, **params: Any):
         super().__init__(**params)
+
+
+# Default state type is DictState for the generic type
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)
 
 
 class InMemoryStateStore(Generic[MODEL_T]):

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,7 @@ dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "llama-index-instrumentation" },
     { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -325,6 +326,7 @@ requires-dist = [
     { name = "llama-index-instrumentation", specifier = ">=0.1.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.39.0" },
+    { name = "typing-extensions", specifier = ">=4.6.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.32.0" },
 ]
 provides-extras = ["server"]


### PR DESCRIPTION
Since we made the `Context` a generic, mypy will complain if you don't provide a type annotation (and nearly all our docs skip an annotation for the generic)

This PR adds a default to the generic 