### PR TITLE
feat: add gather in step decorator

### DIFF
--- a/src/workflows/context/context.py
+++ b/src/workflows/context/context.py
@@ -830,6 +830,9 @@ class Context(Generic[MODEL_T]):
             if type(ev) not in config.accepted_events:
                 continue
 
+            if config.gather:
+                self.collect_events(ev, config.gather)
+
             if verbose and name != "_done":
                 print(f"Running step {name}")
 

--- a/src/workflows/context/context.py
+++ b/src/workflows/context/context.py
@@ -831,7 +831,7 @@ class Context(Generic[MODEL_T]):
                 continue
 
             if config.gather:
-                self.collect_events(ev, config.gather)
+                self.gather_events(ev, config.gather)
 
             if verbose and name != "_done":
                 print(f"Running step {name}")

--- a/src/workflows/decorators.py
+++ b/src/workflows/decorators.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .errors import WorkflowValidationError
 from .resource import ResourceDefinition
+from .events import EventType
 from .utils import (
     inspect_signature,
     is_free_function,
@@ -31,12 +32,14 @@ class StepConfig(BaseModel):
     retry_policy: RetryPolicy | None
     resources: list[ResourceDefinition]
     context_state_type: Type[BaseModel] | None = Field(default=None)
+    gather: list[EventType] | None = Field(default=None)
 
 
 def step(
     *args: Any,
     workflow: Type["Workflow"] | None = None,
     num_workers: int = 4,
+    gather: list[EventType] | None = None,
     retry_policy: RetryPolicy | None = None,
 ) -> Callable:
     """
@@ -104,6 +107,7 @@ def step(
             num_workers=num_workers,
             retry_policy=retry_policy,
             resources=spec.resources,
+            gather=gather,
         )
 
         # If this is a free function, call add_step() explicitly.

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -15,11 +15,12 @@ def test_decorated_config(workflow: Workflow) -> None:
     def f(self, ev: Event) -> Event:  # type: ignore
         return Event()
 
-    res = step(workflow=workflow.__class__)(f)
+    res = step(workflow=workflow.__class__, gather=[Event])(f)
     config = getattr(res, "__step_config")
     assert config.accepted_events == [Event]
     assert config.event_name == "ev"
     assert config.return_types == [Event]
+    assert config.gather == [Event]
 
 
 def test_decorate_method() -> None:

--- a/tests/test_workflow_send_gather.py
+++ b/tests/test_workflow_send_gather.py
@@ -71,16 +71,13 @@ class EmailSenderWorkflow(Workflow):
         counter.update(success=sent)
         return ProcessEmailEvent(sent=sent, time=time.time())
 
-    @step
+    @step(gather=[ProcessEmailEvent])
     async def output(
         self,
         ev: ProcessEmailEvent,
         ctx: Context,
         counter: Annotated[EmailCounter, Resource(get_counter)],
     ) -> Union[StopEvent, None]:
-        events = ctx.gather_events(ev, [type(ev)])
-        if events:
-            return None
         return StopEvent(result=f"Sent {counter.success} emails; {counter.fail} failed")
 
 


### PR DESCRIPTION
We add a `gather` property in `StepConfig` which then, in `_step_worker`, will trigger the collection of events before the execution of the step

Example usage:

```python
class TestWf(Workflow):
    @step
    async def step_one(self, ev: StartEvent, ctx: Context[WfState]) -> SomeEvent | None:
        print("Received message " + ev.message)
        ctx.send_events([SomeEvent(data="hello"), SomeEvent(data="ciao")])
    
    @step
    async def step_process(self, ev: SomeEvent, counter: Annotated[Counter, Resource(get_counter)]) -> SecondEvent:
        counter.update()
        print("Processing message " + ev.data)
        time.sleep(1)
        return SecondEvent(greeting=ev.data)

    @step(gather=[SomeEvent])
    async def step_two(self, ev: SecondEvent, counter: Annotated[Counter, Resource(get_counter)]) -> StopEvent:
        print(ev.greeting)
        time.sleep(1)
        return StopEvent(result=f"Processed {counter.messages} messages")
```
