### PR TITLE
feat: Add TypeScript SDK generation and publishing pipeline

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,34 +1,240 @@
-name: Publish to PyPI and GitHub
+name: Publish Release
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_python:
+        description: 'Publish Python package to PyPI'
+        required: false
+        default: true
+        type: boolean
+      publish_sdk:
+        description: 'Publish TypeScript SDK to npm'
+        required: false
+        default: true
+        type: boolean
   push:
     tags:
       - "v*"
 
 jobs:
-  build-n-publish:
-    name: Build and publish to PyPI
+  # Job 1: Validate versions
+  validate-version:
+    name: Validate Version Consistency
     if: github.repository == 'run-llama/workflows-py'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Extract and validate version
+        id: version
+        run: |
+          # Extract version from pyproject.toml (single source of truth)
+          PYPROJECT_VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
+          echo "version=$PYPROJECT_VERSION" >> $GITHUB_OUTPUT
+          echo "PyProject version: $PYPROJECT_VERSION"
+          
+          # If this is a tag push, validate it matches
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+            
+            # Remove 'v' prefix if present for comparison
+            TAG_VERSION="${TAG#v}"
+            
+            echo "Git tag: $TAG (version: $TAG_VERSION)"
+            
+            # Validate that tag matches pyproject.toml version
+            if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
+              echo "❌ Error: Tag version ($TAG_VERSION) does not match pyproject.toml version ($PYPROJECT_VERSION)"
+              echo "Please ensure the Git tag matches the version in pyproject.toml"
+              exit 1
+            fi
+            
+            echo "✅ Version validation passed: $PYPROJECT_VERSION"
+          else
+            echo "Manual workflow dispatch - using version from pyproject.toml"
+            echo "tag=" >> $GITHUB_OUTPUT
+          fi
+
+  # Job 2: Build and publish Python package
+  publish-python:
+    name: Publish Python Package to PyPI
+    needs: validate-version
+    if: |
+      github.repository == 'run-llama/workflows-py' &&
+      (github.event_name == 'push' || github.event.inputs.publish_python == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
+    
     steps:
       - uses: actions/checkout@v4
-
+      
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      - name: Build and publish
+      
+      - name: Build Python package
+        run: uv build
+      
+      - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          uv build
-          uv publish
+        run: uv publish
+      
+      - name: Upload Python artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
 
+  # Job 3: Build and publish TypeScript SDK
+  publish-sdk:
+    name: Publish TypeScript SDK to npm
+    needs: validate-version
+    if: |
+      github.repository == 'run-llama/workflows-py' &&
+      (github.event_name == 'push' || github.event.inputs.publish_sdk == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # For npm provenance
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      
+      - name: Install Python dependencies with uv
+        run: |
+          uv sync --extra server
+      
+      - name: Update SDK version
+        run: |
+          cd client-sdk
+          # Update package.json version to match Python version from validation job
+          npm pkg set version="${{ needs.validate-version.outputs.version }}"
+      
+      - name: Generate TypeScript SDK
+        run: |
+          uv run hatch run server:sdk-generate
+      
+      - name: Build and validate SDK
+        run: |
+          cd client-sdk
+          # Type check first
+          pnpm run typecheck
+          # Clean and build
+          pnpm run clean
+          pnpm run build
+      
+      - name: Publish to npm
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+        working-directory: client-sdk
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Check if this version already exists on npm
+          if npm view @llamaindex/workflows-client@${{ needs.validate-version.outputs.version }} > /dev/null 2>&1; then
+            echo "Version ${{ needs.validate-version.outputs.version }} already exists on npm, skipping publish"
+          else
+            pnpm publish --access public --provenance
+          fi
+      
+      - name: Create SDK tarball
+        run: |
+          cd client-sdk
+          pnpm pack
+          mv *.tgz ../sdk-package.tgz
+      
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-package
+          path: sdk-package.tgz
+
+  # Job 4: Create GitHub Release with all artifacts
+  create-release:
+    name: Create GitHub Release
+    needs: [validate-version, publish-python, publish-sdk]
+    # Only create release if jobs succeeded/skipped and it's a tag push
+    if: |
+      always() &&
+      github.repository == 'run-llama/workflows-py' &&
+      startsWith(github.ref, 'refs/tags/') &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download Python artifacts
+        if: needs.publish-python.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+      
+      - name: Download SDK artifact
+        if: needs.publish-sdk.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-package
+      
+      - name: Determine release artifacts
+        id: artifacts
+        run: |
+          ARTIFACTS=""
+          if [ -d "dist" ]; then
+            ARTIFACTS="dist/*"
+          fi
+          if [ -f "sdk-package.tgz" ]; then
+            if [ -n "$ARTIFACTS" ]; then
+              ARTIFACTS="${ARTIFACTS},sdk-package.tgz"
+            else
+              ARTIFACTS="sdk-package.tgz"
+            fi
+          fi
+          echo "artifacts=$ARTIFACTS" >> $GITHUB_OUTPUT
+      
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "dist/*"
+          artifacts: ${{ steps.artifacts.outputs.artifacts }}
           generateReleaseNotes: true
+          name: ${{ needs.validate-version.outputs.tag }}
+          body: |
+            ## 📦 Release Artifacts
+            
+            ### Python Package
+            - PyPI: `pip install llama-index-workflows`
+            - Install specific version: `pip install llama-index-workflows==${{ needs.validate-version.outputs.version }}`
+            
+            ### TypeScript SDK  
+            - npm: `pnpm add @llamaindex/workflows-client`
+            - Install specific version: `pnpm add @llamaindex/workflows-client@${{ needs.validate-version.outputs.version }}`
+            
+            ### Downloads
+            - Python wheel and source distribution attached below (if published)
+            - TypeScript SDK tarball attached below (if published)
+            
+            ---
+            See changelog below for what's new in this release.

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -1,0 +1,124 @@
+name: SDK CI
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'src/workflows/server/**'
+      - 'scripts/generate_sdk.py'
+      - 'client-sdk/**'
+      - 'pyproject.toml'
+      - '.github/workflows/sdk-ci.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'src/workflows/server/**'
+      - 'scripts/generate_sdk.py'
+      - 'client-sdk/**'
+      - 'pyproject.toml'
+      - '.github/workflows/sdk-ci.yml'
+
+jobs:
+  validate-sdk-generation:
+    name: Validate SDK Generation
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      
+      - name: Install Python dependencies
+        run: |
+          uv sync --extra server
+      
+      - name: Generate SDK
+        run: |
+          uv run hatch run server:sdk-generate
+      
+      - name: Validate SDK build
+        run: |
+          cd client-sdk
+          # Clean and build to ensure everything works
+          pnpm run clean
+          pnpm run build
+      
+      - name: Check generated files exist
+        run: |
+          test -f client-sdk/src/generated/index.ts
+          test -f client-sdk/src/generated/sdk.gen.ts
+          test -f client-sdk/src/generated/types.gen.ts
+          test -f client-sdk/dist/index.js
+          test -f client-sdk/dist/index.mjs
+          test -f client-sdk/dist/index.d.ts
+      
+      - name: Upload SDK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-sdk-${{ github.sha }}
+          path: |
+            client-sdk/src/generated/
+            client-sdk/dist/
+          retention-days: 7
+      
+      - name: Version consistency check
+        run: |
+          # Check that version in pyproject.toml matches package.json
+          PYTHON_VERSION=$(grep '^version' pyproject.toml | cut -d'"' -f2)
+          SDK_VERSION=$(node -p "require('./client-sdk/package.json').version")
+          
+          echo "Python version: $PYTHON_VERSION"
+          echo "SDK version: $SDK_VERSION"
+          
+          if [ "$PYTHON_VERSION" != "$SDK_VERSION" ]; then
+            echo "⚠️ Warning: Version mismatch between Python ($PYTHON_VERSION) and SDK ($SDK_VERSION)"
+            echo "This is expected in development, but should match in releases."
+          else
+            echo "✅ Versions match: $PYTHON_VERSION"
+          fi
+      
+      - name: SDK size check
+        run: |
+          # Check that the generated SDK isn't too large
+          SDK_SIZE=$(du -sk client-sdk/dist | cut -f1)
+          echo "SDK dist size: ${SDK_SIZE}KB"
+          
+          # Warn if SDK is larger than 1MB
+          if [ $SDK_SIZE -gt 1024 ]; then
+            echo "⚠️ Warning: SDK size is larger than 1MB"
+          fi
+      
+      - name: Summary
+        run: |
+          echo "## 📦 SDK CI Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ SDK generated successfully" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ TypeScript compilation passed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ All expected files present" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Generated Files" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          ls -la client-sdk/src/generated/ >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Build Output" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          ls -la client-sdk/dist/ >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ cython_debug/
 .claude/
 .cursorignore
 .cursorindexingignore
+
+# Generated files
+openapi.json

--- a/client-sdk/.gitignore
+++ b/client-sdk/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+src/generated/
+*.log
+.DS_Store
+pnpm-lock.yaml
+package-lock.json

--- a/client-sdk/README.md
+++ b/client-sdk/README.md
@@ -1,0 +1,82 @@
+# @llamaindex/workflows-client
+
+TypeScript client for LlamaIndex Workflows server.
+
+## Installation
+
+```bash
+pnpm add @llamaindex/workflows-client
+# or
+npm install @llamaindex/workflows-client
+```
+
+## Usage
+
+```typescript
+import { client } from '@llamaindex/workflows-client';
+
+// Initialize the client
+client.setConfig({
+  baseUrl: 'http://localhost:8000'
+});
+
+// List available workflows
+const { data: workflows } = await client.GET('/workflows');
+
+// Run a workflow synchronously
+const { data: result } = await client.POST('/workflows/{name}/run', {
+  params: {
+    path: { name: 'my-workflow' }
+  },
+  body: {
+    context: {
+      // Your context data
+    },
+    kwargs: {
+      // Additional arguments
+    }
+  }
+});
+
+// Run a workflow asynchronously
+const { data: async_result } = await client.POST('/workflows/{name}/run-nowait', {
+  params: {
+    path: { name: 'my-workflow' }
+  },
+  body: {
+    // Same as above
+  }
+});
+
+// Get result later
+const { data: final_result } = await client.GET('/results/{handler_id}', {
+  params: {
+    path: { handler_id: async_result.handler_id }
+  }
+});
+
+// Stream events
+const { data: events } = await client.GET('/events/{handler_id}', {
+  params: {
+    path: { handler_id: async_result.handler_id },
+    query: { sse: true }
+  }
+});
+```
+
+## Development
+
+This client is auto-generated from the OpenAPI schema. To regenerate:
+
+```bash
+# From the root of the workflows-py repository
+python scripts/generate_sdk.py
+
+# Or using pnpm scripts from this directory
+pnpm run generate
+pnpm run build
+```
+
+## License
+
+MIT

--- a/client-sdk/openapi-ts.config.ts
+++ b/client-sdk/openapi-ts.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@hey-api/openapi-ts';
+
+export default defineConfig({
+  input: '../openapi.json',
+  output: 'src/generated',
+});

--- a/client-sdk/package.json
+++ b/client-sdk/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@llamaindex/workflows-client",
+  "version": "2.0.0",
+  "description": "TypeScript client for LlamaIndex Workflows server",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "generate": "pnpx @hey-api/openapi-ts",
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist src/generated",
+    "prepublishOnly": "pnpm run build"
+  },
+  "keywords": [
+    "llamaindex",
+    "workflows",
+    "api",
+    "client",
+    "typescript"
+  ],
+  "author": "LlamaIndex",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/run-llama/workflows-py"
+  },
+  "devDependencies": {
+    "@hey-api/openapi-ts": "^0.82.4",
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
+}

--- a/client-sdk/package.json
+++ b/client-sdk/package.json
@@ -13,6 +13,7 @@
     "generate": "pnpx @hey-api/openapi-ts",
     "build": "tsup",
     "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist src/generated",
     "prepublishOnly": "pnpm run build"
   },

--- a/client-sdk/src/index.ts
+++ b/client-sdk/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @llamaindex/workflows-client
+ * 
+ * TypeScript client for LlamaIndex Workflows server.
+ * 
+ * @license MIT
+ */
+
+// Re-export everything from generated code
+export * from './generated';
+
+// Export version from package.json
+export { version as VERSION } from '../package.json';

--- a/client-sdk/tsconfig.json
+++ b/client-sdk/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/client-sdk/tsup.config.ts
+++ b/client-sdk/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  shims: true,
+  minify: false,
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-server = ["starlette>=0.39.0", "uvicorn>=0.32.0"]
+server = ["starlette>=0.39.0", "uvicorn>=0.32.0", "pyyaml>=6.0.2"]
 
 [tool.basedpyright]
 typeCheckingMode = "standard"
@@ -44,3 +44,4 @@ features = ["server"]
 
 [tool.hatch.envs.server.scripts]
 openapi = "python -m workflows.server.server --output openapi.json"
+sdk-generate = "python scripts/generate_sdk.py"

--- a/scripts/generate_sdk.py
+++ b/scripts/generate_sdk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+Generate TypeScript SDK from WorkflowServer OpenAPI schema.
+
+This script:
+1. Generates OpenAPI schema from WorkflowServer
+2. Calls @hey-api/openapi-ts to generate TypeScript client
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Add parent directory to path to import workflows
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from workflows.server import WorkflowServer
+
+
+def main():
+    # Paths
+    root_dir = Path(__file__).parent.parent
+    openapi_path = root_dir / "openapi.json"
+    client_sdk_dir = root_dir / "client-sdk"
+    
+    # Step 1: Generate OpenAPI schema
+    print("Generating OpenAPI schema...")
+    server = WorkflowServer()
+    schema = server.openapi_schema()
+    
+    # Enhance the schema with better metadata
+    schema["info"]["title"] = "LlamaIndex Workflows API"
+    schema["info"]["description"] = "TypeScript client for LlamaIndex Workflows server"
+    
+    # Save OpenAPI schema
+    with open(openapi_path, "w") as f:
+        json.dump(schema, f, indent=2)
+    print(f"✅ OpenAPI schema saved to {openapi_path}")
+    
+    # Step 2: Install dependencies if needed
+    print("\nInstalling pnpm dependencies...")
+    subprocess.run(
+        ["pnpm", "install"],
+        cwd=client_sdk_dir,
+        check=True
+    )
+    
+    # Step 3: Generate TypeScript client
+    print("Generating TypeScript client...")
+    subprocess.run(
+        ["pnpm", "run", "generate"],
+        cwd=client_sdk_dir,
+        check=True
+    )
+    
+    # Step 4: Build the SDK
+    print("Building TypeScript SDK...")
+    subprocess.run(
+        ["pnpm", "run", "build"],
+        cwd=client_sdk_dir,
+        check=True
+    )
+    
+    print(f"\n✅ SDK generated successfully in {client_sdk_dir}")
+    print("   Generated files are in client-sdk/src/generated/")
+    print("   Built files are in client-sdk/dist/")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -533,6 +533,7 @@ dependencies = [
 
 [package.optional-dependencies]
 server = [
+    { name = "pyyaml" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -553,6 +554,7 @@ requires-dist = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'", specifier = ">=0.2.2" },
     { name = "llama-index-instrumentation", specifier = ">=0.1.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6.0.2" },
     { name = "starlette", marker = "extra == 'server'", specifier = ">=0.39.0" },
     { name = "typing-extensions", specifier = ">=4.6.0" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.32.0" },


### PR DESCRIPTION
## Summary
- Adds automated TypeScript SDK generation from the Python server's OpenAPI schema
- Creates a unified release pipeline with proper version synchronization
- Uses `@llamaindex/workflows-client` as the npm package name

## Changes
### SDK Generation
- Added `scripts/generate_sdk.py` to orchestrate SDK generation using @hey-api/openapi-ts
- Configured SDK to be generated from Starlette's OpenAPI schema
- SDK artifacts are gitignored, only configuration files are committed

### CI/CD Pipeline
- **Version Validation**: New job validates Git tags match pyproject.toml version
- **Separated Jobs**: Python and TypeScript publishing are independent jobs
- **SDK CI**: Added workflow to validate SDK generation on every PR
- **Single Source of Truth**: pyproject.toml version drives both Python and SDK versions

### Dependencies
- Added `pyyaml` to server dependencies for OpenAPI schema generation
- Configured pnpm as the package manager for Node.js operations
- Added typecheck script to package.json for validation

## Test Plan
- [x] SDK generation works locally with `uv run hatch run server:sdk-generate`
- [x] Version validation correctly fails on mismatched tags (tested with act)
- [x] Version validation passes with matching tags (tested with act)
- [x] Manual workflow dispatch uses pyproject.toml version (tested with act)
- [ ] Release workflow publishes both packages successfully
- [ ] SDK CI validates generation on PR

🤖 Generated with [Claude Code](https://claude.ai/code)