### PR TITLE
Add better error handling and lifecycle handling to workflow server

### DIFF
--- a/src/workflows/handler.py
+++ b/src/workflows/handler.py
@@ -30,11 +30,13 @@ class WorkflowHandler(asyncio.Future[RunResultT]):
         *args: Any,
         ctx: Context | None = None,
         run_id: str | None = None,
+        run_task: asyncio.Task[None] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.run_id = run_id
         self._ctx = ctx
+        self._run_task = run_task
         self._all_events_consumed = False
 
     @property

--- a/tests/server/test_server_endpoints.py
+++ b/tests/server/test_server_endpoints.py
@@ -26,7 +26,7 @@ def server() -> WorkflowServer:
 
 
 @pytest_asyncio.fixture
-async def async_client(
+async def client(
     server: WorkflowServer,
     simple_test_workflow: Workflow,
     error_workflow: Workflow,
@@ -37,496 +37,468 @@ async def async_client(
     server.add_workflow("error", error_workflow)
     server.add_workflow("streaming", streaming_workflow)
     server.add_workflow("interactive", interactive_workflow)
-    transport = ASGITransport(app=server.app)
-    yield AsyncClient(transport=transport, base_url="http://test")
-    await server._close()
+    async with server:
+        transport = ASGITransport(app=server.app)
+
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_start_event_str_plain(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Provide start_event as a plain JSON string (no discriminators)
-        start_event_json = json.dumps({"message": "plain string start"})
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": start_event_json}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: plain string start"
+    # Provide start_event as a plain JSON string (no discriminators)
+    start_event_json = json.dumps({"message": "plain string start"})
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": start_event_json}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: plain string start"
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_start_event_dict_with_discriminators(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Provide start_event as a dict with pydantic discriminators
-        start_event_dict = {
-            "__is_pydantic": True,
-            "value": {"_data": {"message": "dict with discriminators"}},
-            "qualified_name": "workflows.events.StartEvent",
-        }
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": start_event_dict}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: dict with discriminators"
+    # Provide start_event as a dict with pydantic discriminators
+    start_event_dict = {
+        "__is_pydantic": True,
+        "value": {"_data": {"message": "dict with discriminators"}},
+        "qualified_name": "workflows.events.StartEvent",
+    }
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": start_event_dict}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: dict with discriminators"
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_start_event_dict_plain(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Provide start_event as a plain dict (no discriminators)
-        start_event_dict = {"message": "plain dict start"}
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": start_event_dict}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: plain dict start"
+    # Provide start_event as a plain dict (no discriminators)
+    start_event_dict = {"message": "plain dict start"}
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": start_event_dict}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: plain dict start"
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_nonconforming_start_event_type(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Provide start_event of a different event type than the workflow's StartEvent
-        wrong_event_dict = {
-            "__is_pydantic": True,
-            "value": {"_data": {"message": "should fail"}},
-            "qualified_name": "workflows.events.StopEvent",
-        }
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": wrong_event_dict}
-        )
-        assert response.status_code == 400
-        assert "Start event must be an instance of" in response.text
+    # Provide start_event of a different event type than the workflow's StartEvent
+    wrong_event_dict = {
+        "__is_pydantic": True,
+        "value": {"_data": {"message": "should fail"}},
+        "qualified_name": "workflows.events.StopEvent",
+    }
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": wrong_event_dict}
+    )
+    assert response.status_code == 400
+    assert "Start event must be an instance of" in response.text
 
 
 @pytest.mark.asyncio
-async def test_health_check(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.get("/health")
-        assert response.status_code == 200
-        assert response.json() == {"status": "healthy"}
+async def test_health_check(client: AsyncClient) -> None:
+    response = await client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
 
 
 @pytest.mark.asyncio
-async def test_list_workflows(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.get("/workflows")
-        assert response.status_code == 200
-        data = response.json()
-        assert "workflows" in data
-        assert set(data["workflows"]) == {"test", "error", "streaming", "interactive"}
+async def test_list_workflows(client: AsyncClient) -> None:
+    response = await client.get("/workflows")
+    assert response.status_code == 200
+    data = response.json()
+    assert "workflows" in data
+    assert set(data["workflows"]) == {"test", "error", "streaming", "interactive"}
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_success(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post(
-            "/workflows/test/run", json={"kwargs": {"message": "hello"}}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "result" in data
-        assert data["result"] == "processed: hello"
+async def test_run_workflow_success(client: AsyncClient) -> None:
+    response = await client.post(
+        "/workflows/test/run", json={"kwargs": {"message": "hello"}}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "result" in data
+    assert data["result"] == "processed: hello"
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_no_kwargs(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post("/workflows/test/run", json={})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: default"
+async def test_run_workflow_no_kwargs(client: AsyncClient) -> None:
+    response = await client.post("/workflows/test/run", json={})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: default"
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_context(
-    async_client: AsyncClient, server: WorkflowServer
+    client: AsyncClient, server: WorkflowServer
 ) -> None:
-    async with async_client as client:
-        ctx: Context = Context(server._workflows["test"])
-        await ctx.store.set("test_param", "message from context")
-        ctx_dict = ctx.to_dict()
-        response = await client.post("/workflows/test/run", json={"context": ctx_dict})
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: message from context"
+    ctx: Context = Context(server._workflows["test"])
+    await ctx.store.set("test_param", "message from context")
+    ctx_dict = ctx.to_dict()
+    response = await client.post("/workflows/test/run", json={"context": ctx_dict})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: message from context"
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_with_start_event(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Test with simple start event containing message
-        start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "start event message"}}, "qualified_name": "workflows.events.StartEvent"}'
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": start_event_json}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["result"] == "processed: start event message"
+async def test_run_workflow_with_start_event(client: AsyncClient) -> None:
+    # Test with simple start event containing message
+    start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "start event message"}}, "qualified_name": "workflows.events.StartEvent"}'
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": start_event_json}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "processed: start event message"
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_not_found(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post("/workflows/nonexistent/run", json={})
-        assert response.status_code == 404
+async def test_run_workflow_not_found(client: AsyncClient) -> None:
+    response = await client.post("/workflows/nonexistent/run", json={})
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_error(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post("/workflows/error/run", json={})
-        assert response.status_code == 500
-        assert "Test error" in response.text
+async def test_run_workflow_error(client: AsyncClient) -> None:
+    response = await client.post("/workflows/error/run", json={})
+    assert response.status_code == 500
+    assert "Test error" in response.text
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_invalid_json(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post(
-            "/workflows/test/run",
-            content="invalid json",
-            headers={"Content-Type": "application/json"},
-        )
-        assert response.status_code == 500
+async def test_run_workflow_invalid_json(client: AsyncClient) -> None:
+    response = await client.post(
+        "/workflows/test/run",
+        content="invalid json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 500
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_invalid_start_event(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Test with invalid JSON for start_event
-        response = await client.post(
-            "/workflows/test/run", json={"start_event": "invalid json"}
-        )
-        assert response.status_code == 400
-        assert "Validation error for 'start_event'" in response.text
+async def test_run_workflow_invalid_start_event(client: AsyncClient) -> None:
+    # Test with invalid JSON for start_event
+    response = await client.post(
+        "/workflows/test/run", json={"start_event": "invalid json"}
+    )
+    assert response.status_code == 400
+    assert "Validation error for 'start_event'" in response.text
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_nowait_invalid_start_event(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Test with invalid JSON for start_event in nowait endpoint
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"start_event": "invalid json"}
-        )
-        assert response.status_code == 400
-        assert "Validation error for 'start_event'" in response.text
+    # Test with invalid JSON for start_event in nowait endpoint
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"start_event": "invalid json"}
+    )
+    assert response.status_code == 400
+    assert "Validation error for 'start_event'" in response.text
 
 
 @pytest.mark.asyncio
 async def test_run_workflow_with_start_event_and_kwargs(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Test that start_event takes precedence over kwargs
-        start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "start event priority"}}, "qualified_name": "workflows.events.StartEvent"}'
-        response = await client.post(
-            "/workflows/test/run",
-            json={
-                "start_event": start_event_json,
-                "kwargs": {"message": "kwargs message"},
-            },
-        )
-        assert response.status_code == 200
-        data = response.json()
-        # start_event should take precedence
-        assert data["result"] == "processed: start event priority"
+    # Test that start_event takes precedence over kwargs
+    start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "start event priority"}}, "qualified_name": "workflows.events.StartEvent"}'
+    response = await client.post(
+        "/workflows/test/run",
+        json={
+            "start_event": start_event_json,
+            "kwargs": {"message": "kwargs message"},
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    # start_event should take precedence
+    assert data["result"] == "processed: start event priority"
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_nowait_success(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"kwargs": {"message": "async"}}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "handler_id" in data
-        assert "status" in data
-        assert data["status"] == "started"
-        assert len(data["handler_id"]) == 10  # Default nanoid length
+async def test_run_workflow_nowait_success(client: AsyncClient) -> None:
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"kwargs": {"message": "async"}}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "handler_id" in data
+    assert "status" in data
+    assert data["status"] == "started"
+    assert len(data["handler_id"]) == 10  # Default nanoid length
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_nowait_with_start_event(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Test with start event containing message
-        start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "async start event"}}, "qualified_name": "workflows.events.StartEvent"}'
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"start_event": start_event_json}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "handler_id" in data
-        assert "status" in data
-        assert data["status"] == "started"
-        assert len(data["handler_id"]) == 10  # Default nanoid length
+async def test_run_workflow_nowait_with_start_event(client: AsyncClient) -> None:
+    # Test with start event containing message
+    start_event_json = '{"__is_pydantic": true, "value": {"_data": {"message": "async start event"}}, "qualified_name": "workflows.events.StartEvent"}'
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"start_event": start_event_json}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "handler_id" in data
+    assert "status" in data
+    assert data["status"] == "started"
+    assert len(data["handler_id"]) == 10  # Default nanoid length
 
 
 @pytest.mark.asyncio
-async def test_run_workflow_nowait_not_found(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post("/workflows/nonexistent/run-nowait", json={})
-        assert response.status_code == 404
+async def test_run_workflow_nowait_not_found(client: AsyncClient) -> None:
+    response = await client.post("/workflows/nonexistent/run-nowait", json={})
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_get_workflow_result(
-    async_client: AsyncClient, server: WorkflowServer
-) -> None:
+async def test_get_workflow_result(client: AsyncClient, server: WorkflowServer) -> None:
     # Setup a context to test all the code paths
     ctx: Context = Context(server._workflows["test"])
     await ctx.store.set("test_param", "message from context")
     ctx_dict = ctx.to_dict()
-    async with async_client as client:
-        # run no-wait
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"context": ctx_dict}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert "handler_id" in data
-        handler_id = data["handler_id"]
+    # run no-wait
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"context": ctx_dict}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "handler_id" in data
+    handler_id = data["handler_id"]
 
-        await asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)
 
-        # get result
-        response = await client.get(f"/results/{handler_id}")
-        assert response.status_code == 200
+    # get result
+    response = await client.get(f"/results/{handler_id}")
+    assert response.status_code == 200
 
-        # Verify the result content
-        result_data = response.json()
-        assert "result" in result_data
-        assert result_data["result"] == "processed: message from context"
+    # Verify the result content
+    result_data = response.json()
+    assert "result" in result_data
+    assert result_data["result"] == "processed: message from context"
 
 
 @pytest.mark.asyncio
 async def test_get_workflow_result_error(
-    async_client: AsyncClient, server: WorkflowServer
+    client: AsyncClient, server: WorkflowServer
 ) -> None:
-    async with async_client as client:
-        # run no-wait
-        response = await client.post("/workflows/error/run-nowait", json={})
-        assert response.status_code == 200
-        data = response.json()
-        assert "handler_id" in data
-        handler_id = data["handler_id"]
+    # run no-wait
+    response = await client.post("/workflows/error/run-nowait", json={})
+    assert response.status_code == 200
+    data = response.json()
+    assert "handler_id" in data
+    handler_id = data["handler_id"]
 
-        await asyncio.sleep(0.1)
+    await asyncio.sleep(0.1)
 
-        # get result
-        response = await client.get(f"/results/{handler_id}")
-        assert response.status_code == 500
+    # get result
+    response = await client.get(f"/results/{handler_id}")
+    assert response.status_code == 500
 
-        # Verify the result content
-        result_data = response.json()
-        assert "error" in result_data
-        assert result_data["error"] == "Test error"
-
-
-@pytest.mark.asyncio
-async def test_get_workflow_result_not_found(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.get("/results/nonexistent")
-        assert response.status_code == 404
+    # Verify the result content
+    result_data = response.json()
+    assert "error" in result_data
+    assert result_data["error"] == "Test error"
 
 
 @pytest.mark.asyncio
-async def test_stream_events_success(async_client: AsyncClient) -> None:
+async def test_get_workflow_result_not_found(client: AsyncClient) -> None:
+    response = await client.get("/results/nonexistent")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stream_events_success(client: AsyncClient) -> None:
     """Test streaming events from a workflow."""
-    async with async_client as client:
-        # Start streaming workflow
-        response = await client.post(
-            "/workflows/streaming/run-nowait", json={"kwargs": {"count": 3}}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        handler_id = data["handler_id"]
+    # Start streaming workflow
+    response = await client.post(
+        "/workflows/streaming/run-nowait", json={"kwargs": {"count": 3}}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    handler_id = data["handler_id"]
 
-        # Stream events
-        response = await client.get(f"/events/{handler_id}")
-        assert response.status_code == 200
-        assert response.headers["content-type"] == "application/x-ndjson"
+    # Stream events
+    response = await client.get(f"/events/{handler_id}")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/x-ndjson"
 
-        # Collect streamed events
-        events = []
-        async for line in response.aiter_lines():
-            if line.strip():
-                event_data = json.loads(line)
-                # Filter out empty events
-                if event_data:
-                    events.append(event_data)
+    # Collect streamed events
+    events = []
+    async for line in response.aiter_lines():
+        if line.strip():
+            event_data = json.loads(line)
+            # Filter out empty events
+            if event_data:
+                events.append(event_data)
 
-        # Verify we got the expected events - NDJSON format returns full event objects
-        stream_events = [
-            e for e in events if "value" in e and "message" in e.get("value", {})
-        ]
-        assert len(stream_events) == 3
-        for i, event in enumerate(stream_events):
-            assert "qualified_name" in event
-            assert event["qualified_name"] == "tests.server.conftest.StreamEvent"
-            assert event["value"]["message"] == f"event_{i}"
-            assert event["value"]["sequence"] == i
+    # Verify we got the expected events - NDJSON format returns full event objects
+    stream_events = [
+        e for e in events if "value" in e and "message" in e.get("value", {})
+    ]
+    assert len(stream_events) == 3
+    for i, event in enumerate(stream_events):
+        assert "qualified_name" in event
+        assert event["qualified_name"] == "tests.server.conftest.StreamEvent"
+        assert event["value"]["message"] == f"event_{i}"
+        assert event["value"]["sequence"] == i
 
 
 @pytest.mark.asyncio
-async def test_stream_events_sse(async_client: AsyncClient) -> None:
+async def test_stream_events_sse(client: AsyncClient) -> None:
     """Test streaming events using Server-Sent Events format."""
-    async with async_client as client:
-        # Start streaming workflow
-        response = await client.post(
-            "/workflows/streaming/run-nowait", json={"kwargs": {"count": 2}}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        handler_id = data["handler_id"]
+    # Start streaming workflow
+    response = await client.post(
+        "/workflows/streaming/run-nowait", json={"kwargs": {"count": 2}}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    handler_id = data["handler_id"]
 
-        # Stream events in SSE format
-        response = await client.get(f"/events/{handler_id}?sse=true")
-        assert response.status_code == 200
-        assert response.headers["content-type"].startswith("text/event-stream")
+    # Stream events in SSE format
+    response = await client.get(f"/events/{handler_id}?sse=true")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
 
-        # Collect streamed events
-        events = []
-        current_event = {}
-        async for line in response.aiter_lines():
-            line = line.strip()
-            if line.startswith("event: "):
-                # Extract event type
-                current_event["event_type"] = line.removeprefix(
-                    "event: "
-                )  # Remove "event: " prefix
-            elif line.startswith("data: "):
-                # Extract JSON from SSE data line
-                event_json = line.removeprefix("data: ")  # Remove "data: " prefix
-                event_data = json.loads(event_json)
-                # Filter out empty events
-                if event_data:
-                    current_event["data"] = event_data
-                    events.append(current_event.copy())
-                    current_event = {}
+    # Collect streamed events
+    events = []
+    current_event = {}
+    async for line in response.aiter_lines():
+        line = line.strip()
+        if line.startswith("event: "):
+            # Extract event type
+            current_event["event_type"] = line.removeprefix(
+                "event: "
+            )  # Remove "event: " prefix
+        elif line.startswith("data: "):
+            # Extract JSON from SSE data line
+            event_json = line.removeprefix("data: ")  # Remove "data: " prefix
+            event_data = json.loads(event_json)
+            # Filter out empty events
+            if event_data:
+                current_event["data"] = event_data
+                events.append(current_event.copy())
+                current_event = {}
 
-        # Verify we got event values (not full event objects)
-        # SSE format returns event data with event_type field
-        stream_events = [
-            e
-            for e in events
-            if "data" in e
-            and "message" in e.get("data", {})
-            and "sequence" in e.get("data", {})
-        ]
-        assert len(stream_events) == 2
+    # Verify we got event values (not full event objects)
+    # SSE format returns event data with event_type field
+    stream_events = [
+        e
+        for e in events
+        if "data" in e
+        and "message" in e.get("data", {})
+        and "sequence" in e.get("data", {})
+    ]
+    assert len(stream_events) == 2
 
-        for i, event in enumerate(stream_events):
-            # SSE format returns event type and data separately
-            assert event["event_type"] == "tests.server.conftest.StreamEvent"
-            assert event["data"]["message"] == f"event_{i}"
-            assert event["data"]["sequence"] == i
+    for i, event in enumerate(stream_events):
+        # SSE format returns event type and data separately
+        assert event["event_type"] == "tests.server.conftest.StreamEvent"
+        assert event["data"]["message"] == f"event_{i}"
+        assert event["data"]["sequence"] == i
 
 
 @pytest.mark.asyncio
-async def test_stream_events_not_found(async_client: AsyncClient) -> None:
+async def test_stream_events_not_found(client: AsyncClient) -> None:
     """Test streaming events from non-existent handler."""
-    async with async_client as client:
-        response = await client.get("/events/nonexistent")
-        assert response.status_code == 404
+    response = await client.get("/events/nonexistent")
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_stream_events_no_events(async_client: AsyncClient) -> None:
+async def test_stream_events_no_events(client: AsyncClient) -> None:
     """Test streaming from workflow that emits no events."""
-    async with async_client as client:
-        # Start simple workflow that doesn't emit events
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"kwargs": {"message": "test"}}
-        )
-        assert response.status_code == 200
-        data = response.json()
-        handler_id = data["handler_id"]
+    # Start simple workflow that doesn't emit events
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"kwargs": {"message": "test"}}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    handler_id = data["handler_id"]
 
-        # Try to stream events
-        response = await client.get(f"/events/{handler_id}")
-        assert response.status_code == 200
-        assert response.headers["content-type"] == "application/x-ndjson"
+    # Try to stream events
+    response = await client.get(f"/events/{handler_id}")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/x-ndjson"
 
-        # Should get no stream events (may get StopEvent)
-        events = []
-        async for line in response.aiter_lines():
-            if line.strip():
-                event_data = json.loads(line)
-                # Filter out empty events
-                if event_data:
-                    events.append(event_data)
+    # Should get no stream events (may get StopEvent)
+    events = []
+    async for line in response.aiter_lines():
+        if line.strip():
+            event_data = json.loads(line)
+            # Filter out empty events
+            if event_data:
+                events.append(event_data)
 
-        # Filter for actual stream events (not workflow control events like StopEvent)
-        # Look for events with message and sequence in the value field (StreamEvent pattern)
-        stream_events = [
-            e
-            for e in events
-            if "value" in e
-            and "message" in e.get("value", {})
-            and "sequence" in e.get("value", {})
-        ]
-        assert len(stream_events) == 0
-
-
-@pytest.mark.asyncio
-async def test_get_handlers_empty(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.get("/handlers")
-        assert response.status_code == 200
-        assert response.json() == {"handlers": []}
+    # Filter for actual stream events (not workflow control events like StopEvent)
+    # Look for events with message and sequence in the value field (StreamEvent pattern)
+    stream_events = [
+        e
+        for e in events
+        if "value" in e
+        and "message" in e.get("value", {})
+        and "sequence" in e.get("value", {})
+    ]
+    assert len(stream_events) == 0
 
 
 @pytest.mark.asyncio
-async def test_get_handlers_with_running_workflows(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start multiple workflows
-        response1 = await client.post("/workflows/test/run-nowait", json={})
-        handler_id1 = response1.json()["handler_id"]
+async def test_get_handlers_empty(client: AsyncClient) -> None:
+    response = await client.get("/handlers")
+    assert response.status_code == 200
+    assert response.json() == {"handlers": []}
 
-        response2 = await client.post("/workflows/test/run-nowait", json={})
-        handler_id2 = response2.json()["handler_id"]
 
-        # Get handlers
-        response = await client.get("/handlers")
-        assert response.status_code == 200
-        handlers = response.json()["handlers"]
+@pytest.mark.asyncio
+async def test_get_handlers_with_running_workflows(client: AsyncClient) -> None:
+    # Start multiple workflows
+    response1 = await client.post("/workflows/test/run-nowait", json={})
+    handler_id1 = response1.json()["handler_id"]
 
-        # Should have 2 handlers
-        assert len(handlers) == 2
-        handler_ids = {handler["handler_id"] for handler in handlers}
-        assert handler_id1 in handler_ids
-        assert handler_id2 in handler_ids
+    response2 = await client.post("/workflows/test/run-nowait", json={})
+    handler_id2 = response2.json()["handler_id"]
 
-        # Check all required fields are present
-        for handler in handlers:
-            assert "handler_id" in handler
-            assert "status" in handler
-            assert "result" in handler
-            assert "error" in handler
-            assert handler["status"] == "running"
-            assert handler["result"] is None  # Running workflows don't have results yet
-            assert handler["error"] is None  # Running workflows don't have errors
+    # Get handlers
+    response = await client.get("/handlers")
+    assert response.status_code == 200
+    handlers = response.json()["handlers"]
 
-        # Wait for workflows to complete to avoid warnings
-        for handler_id in [handler_id1, handler_id2]:
+    # Should have 2 handlers
+    assert len(handlers) == 2
+    handler_ids = {handler["handler_id"] for handler in handlers}
+    assert handler_id1 in handler_ids
+    assert handler_id2 in handler_ids
+
+    # Check all required fields are present
+    for handler in handlers:
+        assert "handler_id" in handler
+        assert "status" in handler
+        assert "result" in handler
+        assert "error" in handler
+        assert handler["status"] == "running"
+        assert handler["result"] is None  # Running workflows don't have results yet
+        assert handler["error"] is None  # Running workflows don't have errors
+
+    # Wait for workflows to complete to avoid warnings
+    for handler_id in [handler_id1, handler_id2]:
+        response = await client.get(f"/results/{handler_id}")
+        while response.status_code == 202:
+            await asyncio.sleep(0.01)
             response = await client.get(f"/results/{handler_id}")
-            while response.status_code == 202:
-                await asyncio.sleep(0.01)
-                response = await client.get(f"/results/{handler_id}")
 
 
 async def validate_result_response(
@@ -538,207 +510,190 @@ async def validate_result_response(
 
 
 @pytest.mark.asyncio
-async def test_get_handlers_with_completed_workflow(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start a workflow and wait for it to complete
-        response = await client.post("/workflows/test/run-nowait", json={})
-        handler_id = response.json()["handler_id"]
+async def test_get_handlers_with_completed_workflow(client: AsyncClient) -> None:
+    # Start a workflow and wait for it to complete
+    response = await client.post("/workflows/test/run-nowait", json={})
+    handler_id = response.json()["handler_id"]
 
-        await wait_for_passing(lambda: validate_result_response(handler_id, client))
-        # Get handlers
-        response = await client.get("/handlers")
-        assert response.status_code == 200
-        handlers = response.json()["handlers"]
+    await wait_for_passing(lambda: validate_result_response(handler_id, client))
+    # Get handlers
+    response = await client.get("/handlers")
+    assert response.status_code == 200
+    handlers = response.json()["handlers"]
 
-        # Find our handler
-        handler = next(h for h in handlers if h["handler_id"] == handler_id)
-        assert handler["status"] == "completed"
-        assert handler["result"] == "processed: default"
-        assert handler["error"] is None
-
-
-@pytest.mark.asyncio
-async def test_get_handlers_with_failed_workflow(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start an error workflow
-        response = await client.post("/workflows/error/run-nowait", json={})
-        handler_id = response.json()["handler_id"]
-
-        # Wait a bit for workflow to fail
-        await asyncio.sleep(0.1)
-
-        result = await wait_for_passing(
-            lambda: validate_result_response(handler_id, client, 500)
-        )
-        assert result["error"] == "Test error"
-
-        # Get handlers
-        response = await client.get("/handlers")
-        assert response.status_code == 200
-        handlers = response.json()["handlers"]
-
-        # Find our handler
-        handler = next(h for h in handlers if h["handler_id"] == handler_id)
-        assert handler["status"] == "failed"
-        assert handler["error"] is not None  # Should have an error
-        assert "Test error" in handler["error"]  # Check error message
-        assert handler["result"] is None  # Failed workflows don't have results
+    # Find our handler
+    handler = next(h for h in handlers if h["handler_id"] == handler_id)
+    assert handler["status"] == "completed"
+    assert handler["result"] == "processed: default"
+    assert handler["error"] is None
 
 
 @pytest.mark.asyncio
-async def test_post_event_to_running_workflow(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start an interactive workflow
-        response = await client.post("/workflows/interactive/run-nowait", json={})
-        assert response.status_code == 200
-        handler_id = response.json()["handler_id"]
+async def test_get_handlers_with_failed_workflow(client: AsyncClient) -> None:
+    # Start an error workflow
+    response = await client.post("/workflows/error/run-nowait", json={})
+    handler_id = response.json()["handler_id"]
 
-        # Wait a bit for workflow to start
-        await asyncio.sleep(0.1)
+    # Wait a bit for workflow to fail
+    await asyncio.sleep(0.1)
 
-        serializer = JsonSerializer()
-        event = ExternalEvent(response="Hello from test")
-        event_str = serializer.serialize(event)
+    result = await wait_for_passing(
+        lambda: validate_result_response(handler_id, client, 500)
+    )
+    assert result["error"] == "Test error"
 
-        # Send the event
-        response = await client.post(f"/events/{handler_id}", json={"event": event_str})
-        assert response.status_code == 200
-        assert response.json() == {"status": "sent"}
+    # Get handlers
+    response = await client.get("/handlers")
+    assert response.status_code == 200
+    handlers = response.json()["handlers"]
 
-        result = await wait_for_passing(
-            lambda: validate_result_response(handler_id, client)
-        )
+    # Find our handler
+    handler = next(h for h in handlers if h["handler_id"] == handler_id)
+    assert handler["status"] == "failed"
+    assert handler["error"] is not None  # Should have an error
+    assert "Test error" in handler["error"]  # Check error message
+    assert handler["result"] is None  # Failed workflows don't have results
 
-        assert result["result"] == "received: Hello from test"
+
+@pytest.mark.asyncio
+async def test_post_event_to_running_workflow(client: AsyncClient) -> None:
+    # Start an interactive workflow
+    response = await client.post("/workflows/interactive/run-nowait", json={})
+    assert response.status_code == 200
+    handler_id = response.json()["handler_id"]
+
+    # Wait a bit for workflow to start
+    await asyncio.sleep(0.1)
+
+    serializer = JsonSerializer()
+    event = ExternalEvent(response="Hello from test")
+    event_str = serializer.serialize(event)
+
+    # Send the event
+    response = await client.post(f"/events/{handler_id}", json={"event": event_str})
+    assert response.status_code == 200
+    assert response.json() == {"status": "sent"}
+
+    result = await wait_for_passing(
+        lambda: validate_result_response(handler_id, client)
+    )
+
+    assert result["result"] == "received: Hello from test"
 
 
 @pytest.mark.asyncio
 async def test_get_workflow_result_returns_202_when_pending(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Start workflow that waits for an external event and thus remains pending
-        response = await client.post("/workflows/interactive/run-nowait", json={})
-        assert response.status_code == 200
-        handler_id = response.json()["handler_id"]
+    # Start workflow that waits for an external event and thus remains pending
+    response = await client.post("/workflows/interactive/run-nowait", json={})
+    assert response.status_code == 200
+    handler_id = response.json()["handler_id"]
 
-        response = await client.get(f"/results/{handler_id}")
-        assert response.status_code == 202
+    response = await client.get(f"/results/{handler_id}")
+    assert response.status_code == 202
 
 
 @pytest.mark.asyncio
 async def test_get_workflow_result_multiple_times(
-    async_client: AsyncClient,
+    client: AsyncClient,
 ) -> None:
-    async with async_client as client:
-        # Start and wait for completion
-        response = await client.post(
-            "/workflows/test/run-nowait", json={"kwargs": {"message": "cache-me"}}
-        )
-        assert response.status_code == 200
-        handler_id = response.json()["handler_id"]
+    # Start and wait for completion
+    response = await client.post(
+        "/workflows/test/run-nowait", json={"kwargs": {"message": "cache-me"}}
+    )
+    assert response.status_code == 200
+    handler_id = response.json()["handler_id"]
 
-        # First fetch populates cache
-        first = await wait_for_passing(
-            lambda: validate_result_response(handler_id, client)
-        )
-        assert first["result"] == "processed: cache-me"
+    # First fetch populates cache
+    first = await wait_for_passing(lambda: validate_result_response(handler_id, client))
+    assert first["result"] == "processed: cache-me"
 
-        second = await validate_result_response(handler_id, client)
-        assert second == first
+    second = await validate_result_response(handler_id, client)
+    assert second == first
 
 
 @pytest.mark.asyncio
-async def test_post_event_handler_not_found(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        response = await client.post(
-            "/events/nonexistent_handler", json={"event": "{}"}
-        )
-        assert response.status_code == 404
-        assert "Handler not found" in response.text
+async def test_post_event_handler_not_found(client: AsyncClient) -> None:
+    response = await client.post("/events/nonexistent_handler", json={"event": "{}"})
+    assert response.status_code == 404
+    assert "Handler not found" in response.text
 
 
 @pytest.mark.asyncio
-async def test_post_event_to_completed_workflow(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start and wait for a simple workflow to complete
-        response = await client.post("/workflows/test/run-nowait", json={})
-        handler_id = response.json()["handler_id"]
+async def test_post_event_to_completed_workflow(client: AsyncClient) -> None:
+    # Start and wait for a simple workflow to complete
+    response = await client.post("/workflows/test/run-nowait", json={})
+    handler_id = response.json()["handler_id"]
 
-        # Wait for workflow to complete
+    # Wait for workflow to complete
+    response = await client.get(f"/results/{handler_id}")
+    while response.status_code == 202:
+        await asyncio.sleep(0.01)
         response = await client.get(f"/results/{handler_id}")
-        while response.status_code == 202:
-            await asyncio.sleep(0.01)
-            response = await client.get(f"/results/{handler_id}")
 
-        # Try to send event to completed workflow
-        response = await client.post(f"/events/{handler_id}", json={"event": "{}"})
-        assert response.status_code == 409
-        assert "Workflow already completed" in response.text
+    # Try to send event to completed workflow
+    response = await client.post(f"/events/{handler_id}", json={"event": "{}"})
+    assert response.status_code == 409
+    assert "Workflow already completed" in response.text
 
 
 @pytest.mark.asyncio
-async def test_post_event_invalid_event_data(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start an interactive workflow
-        response = await client.post("/workflows/interactive/run-nowait", json={})
-        handler_id = response.json()["handler_id"]
+async def test_post_event_invalid_event_data(client: AsyncClient) -> None:
+    # Start an interactive workflow
+    response = await client.post("/workflows/interactive/run-nowait", json={})
+    handler_id = response.json()["handler_id"]
 
-        # Send invalid event data
-        response = await client.post(
-            f"/events/{handler_id}", json={"event": "invalid json"}
-        )
-        assert response.status_code == 400
-        assert "Failed to deserialize event" in response.text
+    # Send invalid event data
+    response = await client.post(
+        f"/events/{handler_id}", json={"event": "invalid json"}
+    )
+    assert response.status_code == 400
+    assert "Failed to deserialize event" in response.text
 
 
 @pytest.mark.asyncio
 async def test_post_event_context_not_available(
-    async_client: AsyncClient, server: WorkflowServer
+    client: AsyncClient, server: WorkflowServer
 ) -> None:
-    async with async_client as client:
-        # Dumb test for code coverage. Inject a dummy handler with no context to trigger 500 path
-        wrapper = SimpleNamespace(
-            run_handler=SimpleNamespace(done=lambda: False, ctx=None)
-        )
+    # Dumb test for code coverage. Inject a dummy handler with no context to trigger 500 path
+    wrapper = SimpleNamespace(run_handler=SimpleNamespace(done=lambda: False, ctx=None))
 
-        handler_id = "noctx-1"
-        server._handlers[handler_id] = wrapper  # type: ignore[assignment]
+    handler_id = "noctx-1"
+    server._handlers[handler_id] = wrapper  # type: ignore[assignment]
 
-        try:
-            response = await client.post(f"/events/{handler_id}", json={"event": "{}"})
-            assert response.status_code == 500
-            assert "Context not available" in response.text
-        finally:
-            server._handlers.pop(handler_id, None)
-
-
-@pytest.mark.asyncio
-async def test_post_event_body_parsing_error(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start interactive workflow which waits for an event (keeps running)
-        response = await client.post("/workflows/interactive/run-nowait", json={})
-        assert response.status_code == 200
-        handler_id = response.json()["handler_id"]
-
-        # Send invalid JSON body (not JSON), triggers 500 from body parsing
-        response = await client.post(
-            f"/events/{handler_id}",
-            content="not json",
-            headers={"Content-Type": "application/json"},
-        )
+    try:
+        response = await client.post(f"/events/{handler_id}", json={"event": "{}"})
         assert response.status_code == 500
-        assert "Error processing request" in response.text
+        assert "Context not available" in response.text
+    finally:
+        server._handlers.pop(handler_id, None)
 
 
 @pytest.mark.asyncio
-async def test_post_event_missing_event_data(async_client: AsyncClient) -> None:
-    async with async_client as client:
-        # Start an interactive workflow
-        response = await client.post("/workflows/interactive/run-nowait", json={})
-        handler_id = response.json()["handler_id"]
+async def test_post_event_body_parsing_error(client: AsyncClient) -> None:
+    # Start interactive workflow which waits for an event (keeps running)
+    response = await client.post("/workflows/interactive/run-nowait", json={})
+    assert response.status_code == 200
+    handler_id = response.json()["handler_id"]
 
-        # Send request without event data
-        response = await client.post(f"/events/{handler_id}", json={})
-        assert response.status_code == 400
-        assert "Event data is required" in response.text
+    # Send invalid JSON body (not JSON), triggers 500 from body parsing
+    response = await client.post(
+        f"/events/{handler_id}",
+        content="not json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 500
+    assert "Error processing request" in response.text
+
+
+@pytest.mark.asyncio
+async def test_post_event_missing_event_data(client: AsyncClient) -> None:
+    # Start an interactive workflow
+    response = await client.post("/workflows/interactive/run-nowait", json={})
+    handler_id = response.json()["handler_id"]
+
+    # Send request without event data
+    response = await client.post(f"/events/{handler_id}", json={})
+    assert response.status_code == 400
+    assert "Event data is required" in response.text

--- a/tests/server/test_server_endpoints.py
+++ b/tests/server/test_server_endpoints.py
@@ -37,7 +37,7 @@ async def client(
     server.add_workflow("error", error_workflow)
     server.add_workflow("streaming", streaming_workflow)
     server.add_workflow("interactive", interactive_workflow)
-    async with server:
+    async with server.contextmanager():
         transport = ASGITransport(app=server.app)
 
         async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/server/test_server_persistence.py
+++ b/tests/server/test_server_persistence.py
@@ -10,6 +10,7 @@ from workflows.events import Event, InternalDispatchEvent
 from workflows.server import WorkflowServer
 from workflows import Context
 from workflows.workflow import Workflow
+from workflows.server.abstract_workflow_store import PersistentHandler
 
 from .memory_workflow_store import MemoryWorkflowStore
 from .util import wait_for_passing
@@ -26,8 +27,8 @@ async def server_with_store(
 ) -> AsyncGenerator[WorkflowServer, None]:
     server = WorkflowServer(workflow_store=memory_store)
     server.add_workflow("test", interactive_workflow)
-    yield server
-    await server._close()
+    async with server:
+        yield server
 
 
 @pytest.mark.asyncio
@@ -78,7 +79,6 @@ async def test_resume_active_handlers_across_server_restart(
     memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
     # Seed the store with a valid serialized Context using public API
-    from workflows.server.abstract_workflow_store import PersistentHandler
 
     handler_id = "resume-1"
     initial_ctx = Context(simple_test_workflow).to_dict()
@@ -94,14 +94,13 @@ async def test_resume_active_handlers_across_server_restart(
     # Second server: same store and workflow, explicitly initialize active handlers
     server2 = WorkflowServer(workflow_store=memory_store)
     server2.add_workflow("test", simple_test_workflow)
-    await server2._initialize_active_handlers()
+    async with server2:  # start and stop it
+        # The handler should be registered under the same id
+        assert handler_id in server2._handlers
 
-    # The handler should be registered under the same id
-    assert handler_id in server2._handlers
-
-    # Await its completion through internal result future
-    result = await server2._handlers[handler_id].run_handler
-    assert result == "processed: default"
+        # Await its completion through internal result future
+        result = await server2._handlers[handler_id].run_handler
+        assert result == "processed: default"
 
 
 @pytest.mark.asyncio
@@ -111,35 +110,32 @@ async def test_store_is_updated_on_workflow_failure(
     # Build a server with a failing workflow and the in-memory store
     server = WorkflowServer(workflow_store=memory_store)
     server.add_workflow("error", error_workflow)
+    async with server:
+        # Start a workflow through internal runner to exercise persistence updates
+        handler_id = "fail-1"
+        handler = server._workflows["error"].run()
+        server._run_workflow_handler(handler_id, "error", handler)
 
-    # Start a workflow through internal runner to exercise persistence updates
-    handler_id = "fail-1"
-    handler = server._workflows["error"].run()
-    server._run_workflow_handler(handler_id, "error", handler)
+        # Await the failure of the handler itself
+        with pytest.raises(ValueError, match="Test error"):
+            await handler
 
-    # Await the failure of the handler itself
-    with pytest.raises(ValueError, match="Test error"):
-        await handler
+        # Ensure the background streaming task has completed and persisted status
+        await server._handlers[handler_id].task
+        await asyncio.sleep(0)
 
-    # Ensure the background streaming task has completed and persisted status
-    await server._handlers[handler_id].task
-    await asyncio.sleep(0)
-
-    # Verify store captured the failed status and has a context snapshot
-    assert handler_id in memory_store.handlers
-    persistent = memory_store.handlers[handler_id]
-    assert persistent.workflow_name == "error"
-    assert persistent.status == "failed"
-    assert isinstance(persistent.ctx, dict)
-    await server._close()
+        # Verify store captured the failed status and has a context snapshot
+        assert handler_id in memory_store.handlers
+        persistent = memory_store.handlers[handler_id]
+        assert persistent.workflow_name == "error"
+        assert persistent.status == "failed"
+        assert isinstance(persistent.ctx, dict)
 
 
 @pytest.mark.asyncio
 async def test_startup_ignores_unregistered_workflows(
     memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
-    from workflows.server.abstract_workflow_store import PersistentHandler
-
     # Unknown workflow entry
     await memory_store.update(
         PersistentHandler(
@@ -159,11 +155,127 @@ async def test_startup_ignores_unregistered_workflows(
 
     server = WorkflowServer(workflow_store=memory_store)
     server.add_workflow("test", simple_test_workflow)
-    await server._initialize_active_handlers()
+    async with server:  # start and stop it
+        assert "unknown-1" not in server._handlers
+        assert "known-1" in server._handlers
 
-    assert "unknown-1" not in server._handlers
-    assert "known-1" in server._handlers
+        # Await completion of the resumed known handler
+        result = await server._handlers["known-1"].run_handler
+        assert result == "processed: default"
 
-    # Await completion of the resumed known handler
-    result = await server._handlers["known-1"].run_handler
-    assert result == "processed: default"
+
+def patch_store_update_to_fail(
+    monkeypatch: pytest.MonkeyPatch, store: MemoryWorkflowStore, fail_count: int
+) -> dict[str, int]:
+    """Monkeypatch `store.update` to fail `fail_count` times, then delegate to original.
+
+    Returns a dict with a mutable `count` key to inspect attempt count.
+    """
+    attempts: dict[str, int] = {"count": 0}
+    original_update = store.update
+
+    async def wrapped(handler: PersistentHandler) -> None:
+        attempts["count"] += 1
+        if attempts["count"] <= fail_count:
+            raise Exception(
+                f"Simulated persistence failure (attempt {attempts['count']})"
+            )
+        await original_update(handler)
+
+    monkeypatch.setattr(store, "update", wrapped)
+    return attempts
+
+
+@pytest.mark.asyncio
+async def test_persistence_retries_on_failure(
+    simple_test_workflow: Workflow, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that persistence operations are retried according to backoff configuration."""
+    # Create a store that fails twice then succeeds
+    store = MemoryWorkflowStore()
+    attempts = patch_store_update_to_fail(monkeypatch, store, fail_count=2)
+
+    # Configure server with custom backoff (shorter for testing)
+    server = WorkflowServer(
+        workflow_store=store,
+        persistence_backoff=[0.0, 0.0],  # Very short backoffs for testing
+    )
+    server.add_workflow("test", simple_test_workflow)
+
+    async with server:
+        # Start a workflow to trigger persistence
+        handler_id = "retry-test"
+        handler = server._workflows["test"].run()
+        server._run_workflow_handler(handler_id, "test", handler)
+
+        # Wait for workflow completion
+        result = await server._handlers[handler_id].run_handler
+        assert result == "processed: default"
+
+        # Wait for background streaming task to complete, ignoring its expected exception
+        task = server._handlers[handler_id].task
+        try:
+            await task
+        except Exception:
+            pass
+        await asyncio.sleep(0)
+
+        # Verify that retries occurred and eventually succeeded
+        # There can be multiple checkpoints (initial running, step completion, final completion)
+        # so attempts will be >= initial + retries
+        assert attempts["count"] >= 3  # Initial + 2 retries
+        assert handler_id in store.handlers
+        persistent = store.handlers[handler_id]
+        assert persistent.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_workflow_cancelled_after_all_retries_fail(
+    streaming_workflow: Workflow, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that workflow is cancelled when all persistence retries are exhausted."""
+    # Create a store that always fails
+    store = MemoryWorkflowStore()
+    attempts = patch_store_update_to_fail(
+        monkeypatch, store, fail_count=10
+    )  # Fail more than backoff attempts
+
+    # Configure server with custom backoff (shorter for testing)
+    server = WorkflowServer(
+        workflow_store=store,
+        persistence_backoff=[0.0, 0.0],  # 2 retries, very short backoffs
+    )
+    server.add_workflow("test", streaming_workflow)
+    async with server:
+        try:
+            # Start a workflow to trigger persistence
+            handler_id = "cancel-test"
+            handler = server._workflows["test"].run()
+            server._run_workflow_handler(handler_id, "test", handler)
+
+            # The handler should be cancelled due to persistence failures
+            with pytest.raises(asyncio.CancelledError):
+                await server._handlers[handler_id].run_handler
+
+            # Wait for background streaming task to complete; it raises due to failed checkpoint
+            task = server._handlers[handler_id].task
+            with pytest.raises(Exception):
+                await task
+            await asyncio.sleep(0)
+
+            # Verify that all retry attempts were made
+            assert attempts["count"] == 3  # Initial + 2 retries
+            # Handler should not be successfully stored due to persistent failures
+            assert handler_id not in store.handlers
+        finally:  # clean up log noise. Wait for underlying cancelled workflows to fully resolve
+            tasks = [
+                handler.run_handler._run_task
+                for handler in server._handlers.values()
+                if handler.run_handler._run_task
+            ]
+            for task in tasks:
+                try:
+                    task.cancel()
+                except Exception:
+                    pass
+            await asyncio.sleep(0)


### PR DESCRIPTION
- Adds retries to workflow server persistence, and if it fully fails, cancel/fail the workflow
- Adds workflow error exception logging
- Shims in a task reference such that the persistence tests can wait for things to quiet down before quitting
- Makes WorkflowServer into a context manager. This is related to alleviating some technical debt in LlamaDeploy before that can be paid down, but it also makes it simpler and more obvious how to tear down in tests. Context manager isn't stricly required, but I can also manage this by making a start/stop interface public