### PR TITLE
server: flattened handler metadata in responses, shared OpenAPI components, and test updates

### DIFF
--- a/src/workflows/server/server.py
+++ b/src/workflows/server/server.py
@@ -242,8 +242,16 @@ class WorkflowServer:
                                     "enum": ["running", "completed", "failed"],
                                 },
                                 "started_at": {"type": "string", "format": "date-time"},
-                                "updated_at": {"type": "string", "format": "date-time", "nullable": True},
-                                "completed_at": {"type": "string", "format": "date-time", "nullable": True},
+                                "updated_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": True,
+                                },
+                                "completed_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": True,
+                                },
                                 "error": {"type": "string", "nullable": True},
                                 "result": {"description": "Workflow result value"},
                             },
@@ -969,7 +977,9 @@ class _WorkflowHandler:
             status=self.status,
             started_at=self.started_at.isoformat(),
             updated_at=self.updated_at.isoformat(),
-            completed_at=self.completed_at.isoformat() if self.completed_at is not None else None,
+            completed_at=self.completed_at.isoformat()
+            if self.completed_at is not None
+            else None,
             error=self.error,
             result=self.result,
         )
@@ -1021,6 +1031,7 @@ class _WorkflowHandler:
             else:  # otherwise task completed, so nothing else will be published to the queue
                 queue_get_task.cancel()
                 break
+
 
 @dataclass
 class _NamedWorkflow:

--- a/tests/server/test_server_endpoints.py
+++ b/tests/server/test_server_endpoints.py
@@ -9,7 +9,7 @@ from typing import Any, AsyncGenerator
 
 import pytest
 import pytest_asyncio
-from httpx import ASGITransport, AsyncClient
+from httpx import ASGITransport, AsyncClient, Response
 
 from tests.server.util import wait_for_passing
 from workflows import Context
@@ -732,7 +732,7 @@ async def test_handler_datetime_fields_progress(client: AsyncClient) -> None:
     assert updated_at_2 >= updated_at_1
 
     # Wait for completion and check completed_at
-    async def _wait_done():
+    async def _wait_done() -> Response:
         r = await client.get(f"/results/{handler_id}")
         if r.status_code == 200:
             return r

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-workflows"
-version = "2.2.2"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Summary
- Add and surface flattened runtime handler metadata across server endpoints (no new endpoints).
- Replace per-endpoint, hand-built dicts with a single source `to_dict()` on the server-side wrapper.
- Consolidate OpenAPI schemas via shared components to remove duplication.
- Update tests to reflect expected behavioral changes.

API changes (intentional)
- Flattened metadata fields are now included in these responses:
  - POST /workflows/{name}/run (200)
  - POST /workflows/{name}/run-nowait (200)
  - GET /results/{handler_id} (200, 202)
  - GET /handlers (200, each item)
- Run-nowait response:
  - status was previously “started”; it now returns status: "running".
- Get result error response:
  - GET /results/{handler_id} now returns a detailed error as text/plain on 500 (instead of a JSON object).

Implementation details
- Introduced server-side wrapper `_WorkflowHandler.to_dict()` returning a typed `HandlerDict`.
- Safe accessors on `_WorkflowHandler`:
  - `status`: guards unfinished futures and maps to "running" | "completed" | "failed".
  - `error`: None when unfinished, stringified exception when failed.
  - `result`: None when unfinished; returns final result when completed.
- Centralized response construction to avoid ad-hoc dict assembly.
- OpenAPI:
  - Added shared components:
    - `components.schemas.Handler`: flattened, reusable handler response shape.
    - `components.schemas.HandlersList`: `{ handlers: Handler[] }`.
  - Endpoint docstrings now reference `$ref` to the above, removing duplication.

Backward compatibility notes
- Run-nowait clients should expect `"status": "running"` instead of `"started"`.
- Consumers of GET /results/{handler_id} on error (500) should parse a text/plain body (detailed error message) rather than a JSON object.

Testing
- Updated server tests to reflect the above behavioral changes.
- All server tests passing: 72 passed locally.

Migration/Deployment
- No persistence or schema migrations needed.
- No new configuration flags introduced.
