### PR TITLE
able to pass in previous handler ID to continue runs in WorkflowServer

### DIFF
--- a/src/workflows/server/server.py
+++ b/src/workflows/server/server.py
@@ -374,7 +374,7 @@ class WorkflowServer:
             description: Error running workflow or invalid request body
         """
         workflow = self._extract_workflow(request)
-        context, start_event, run_kwargs = await self._extract_run_params(
+        context, start_event, run_kwargs, handler_id = await self._extract_run_params(
             request, workflow.workflow, workflow.name
         )
 
@@ -384,7 +384,6 @@ class WorkflowServer:
             input_ev = None
 
         try:
-            handler_id = nanoid()
             handler = workflow.workflow.run(
                 ctx=context, start_event=input_ev, **run_kwargs
             )
@@ -533,10 +532,9 @@ class WorkflowServer:
             description: Workflow or handler identifier not found
         """
         workflow = self._extract_workflow(request)
-        context, start_event, run_kwargs = await self._extract_run_params(
+        context, start_event, run_kwargs, handler_id = await self._extract_run_params(
             request, workflow.workflow, workflow.name
         )
-        handler_id = nanoid()
 
         if start_event is not None:
             input_ev = workflow.workflow.start_event_class.model_validate(start_event)
@@ -877,7 +875,8 @@ class WorkflowServer:
 
                 context = Context.from_dict(workflow, persisted_handlers[0].ctx)
 
-            return (context, start_event, run_kwargs)
+            handler_id = handler_id or nanoid()
+            return (context, start_event, run_kwargs, handler_id)
 
         except HTTPException:
             # Re-raise HTTPExceptions as-is (like start_event validation errors)

--- a/tests/server/test_server_persistence.py
+++ b/tests/server/test_server_persistence.py
@@ -328,3 +328,13 @@ async def test_resume_across_runs(
             assert response2.status_code == 200
             resp_data2 = response2.json()
             assert resp_data2["result"] == "count: 8, runs: 2"
+
+            # Verify the handler id is the same
+            assert resp_data2["handler_id"] == handler_id
+
+            # Wait for the handler to be fully persisted as completed
+            await asyncio.sleep(0.1)
+
+            # Verify memory store has only one handler
+            assert len(memory_store.handlers) == 1
+            assert memory_store.handlers[handler_id].status == "completed"


### PR DESCRIPTION
Simple change to fetch completed runs from the context store and re-use them on the next run

This should enable flows that our users are more familiar with

This means users can
- list existing handlers
- continue runs from an existing handler

Next PR should add pagination to the list handlers endpoint, and probably some "delete" endpoint on the handlers?