### PR TITLE
Filter internal events in workflow consumer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,15 +50,6 @@ repos:
     rev: 1.31.1
     hooks:
       - id: basedpyright
-        additional_dependencies:
-          - pydantic==2.11.9
-          - starlette==0.48.0
-          - uvicorn==0.37.0
-          - typing-extensions==4.15.0
-          - llama-index-instrumentation==0.4.1
-          - packaging==25.0
-          - pytest==8.4.2
-          - httpx==0.28.1
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,15 @@ repos:
     rev: 1.31.1
     hooks:
       - id: basedpyright
+        additional_dependencies:
+          - pydantic==2.11.9
+          - starlette==0.48.0
+          - uvicorn==0.37.0
+          - typing-extensions==4.15.0
+          - llama-index-instrumentation==0.4.1
+          - packaging==25.0
+          - pytest==8.4.2
+          - httpx==0.28.1
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/src/workflows/server/server.py
+++ b/src/workflows/server/server.py
@@ -31,6 +31,7 @@ from workflows.events import (
     StepState,
     StepStateChanged,
     StopEvent,
+    InternalDispatchEvent,
 )
 from workflows.handler import WorkflowHandler
 
@@ -639,6 +640,13 @@ class WorkflowServer:
               type: boolean
               default: true
             description: If false, as NDJSON instead of Server-Sent Events.
+          - in: query
+            name: internal
+            required: false
+            schema:
+              type: boolean
+              default: false
+            description: If true, include internal workflow events (e.g., step state changes).
         responses:
           200:
             description: Streaming started
@@ -670,12 +678,17 @@ class WorkflowServer:
 
         # Get raw_event query parameter
         sse = request.query_params.get("sse", "true").lower() == "true"
+        include_internal = request.query_params.get("internal", "false").lower() == "true"
         media_type = "text/event-stream" if sse else "application/x-ndjson"
 
         async def event_stream(handler: _WorkflowHandler) -> AsyncGenerator[str, None]:
             serializer = JsonSerializer()
 
             async for event in handler.iter_events():
+                if not include_internal and isinstance(event, InternalDispatchEvent):
+                    # Skip internal events unless explicitly requested
+                    await asyncio.sleep(0)
+                    continue
                 serialized_event = serializer.serialize(event)
                 if sse:
                     # emit as untyped data. Difficult to subscribe to dynamic event types with SSE.

--- a/src/workflows/server/server.py
+++ b/src/workflows/server/server.py
@@ -641,7 +641,7 @@ class WorkflowServer:
               default: true
             description: If false, as NDJSON instead of Server-Sent Events.
           - in: query
-            name: internal
+            name: include_internal
             required: false
             schema:
               type: boolean
@@ -678,7 +678,9 @@ class WorkflowServer:
 
         # Get raw_event query parameter
         sse = request.query_params.get("sse", "true").lower() == "true"
-        include_internal = request.query_params.get("internal", "false").lower() == "true"
+        include_internal = (
+            request.query_params.get("include_internal", "false").lower() == "true"
+        )
         media_type = "text/event-stream" if sse else "application/x-ndjson"
 
         async def event_stream(handler: _WorkflowHandler) -> AsyncGenerator[str, None]:


### PR DESCRIPTION
Add `internal` query parameter to `/events/{handler_id}` to filter out internal workflow events by default.

---
Linear Issue: [LI-3716](https://linear.app/llamaindex/issue/LI-3716/add-query-parameter-to-hide-internal-events-from-the-subscription)

<a href="https://cursor.com/background-agent?bcId=bc-5ad15fa3-b672-4465-87e2-aad78987a409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ad15fa3-b672-4465-87e2-aad78987a409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

