### PR TITLE
Add consumer lock to events api

### DIFF
--- a/tests/server/test_handler_serialization.py
+++ b/tests/server/test_handler_serialization.py
@@ -36,6 +36,7 @@ async def test__workflow_handler_to_dict_json_roundtrip() -> None:
         run_handler=handler,
         queue=queue,
         task=task,
+        consumer_mutex=asyncio.Lock(),
         handler_id="handler-1",
         workflow_name="wf",
         started_at=now,


### PR DESCRIPTION
Add a consumer lock to the `/events` API handler to ensure reliable event consumption for a single connection, multiple connections are rejected until the first hangs up.
