### PR TITLE
Expose workflow events in server and workflow class

### DIFF
--- a/src/workflows/server/server.py
+++ b/src/workflows/server/server.py
@@ -402,6 +402,7 @@ class WorkflowServer:
         additional_events = self._additional_events.get(name, [])
         if additional_events:
             events.extend(additional_events)
+
         event_objs = []
         for event in events:
             event_objs.append(event.model_json_schema())

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -791,5 +791,6 @@ def test_get_workflow_events() -> None:
 
     events = DummyWorkflow().events
     assert len(events) == 2
-    assert events[0].__name__ == "MyStart"
-    assert events[1].__name__ == "MyStop"
+    event_names = [e.__name__ for e in events]
+    assert "Mystop" in event_names
+    assert "MyStart" in event_names

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -792,5 +792,5 @@ def test_get_workflow_events() -> None:
     events = DummyWorkflow().events
     assert len(events) == 2
     event_names = [e.__name__ for e in events]
-    assert "Mystop" in event_names
+    assert "MyStop" in event_names
     assert "MyStart" in event_names

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -781,3 +781,15 @@ async def test_workflow_validation_steps_cannot_accept_stop_event() -> None:
         match="Step 'bad_step' cannot accept StopEvent. StopEvent signals the end of the workflow. Use a different Event type instead.",
     ):
         await WorkflowTestRunner(InvalidWorkflowSingleStep()).run()
+
+
+def test_get_workflow_events() -> None:
+    class DummyWorkflow(Workflow):
+        @step
+        def one(self, ev: MyStart) -> MyStop:
+            return MyStop(outcome="nope")
+
+    events = DummyWorkflow().events
+    assert len(events) == 2
+    assert events[0].__name__ == "MyStart"
+    assert events[1].__name__ == "MyStop"


### PR DESCRIPTION
- adds a `workflow.events` property to return a list of all known event types
- exposes `/workflows/{name}/events` in `WorkflowServer` to get event schemas
- adds `additional_events` param to `server.add_workflow()` for cases where events are needed beyond what type annotations expose (like special events needed for `ctx.wait_for_event()`)

The motivation for this is to enhance UI's like the workflow debugger, which would benefit from these schemas when exposing a `send_event()` UI component 