### PR TITLE
Powerful event listeners

### DIFF
--- a/src/workflows/context/context.py
+++ b/src/workflows/context/context.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     DefaultDict,
     Generic,
     Tuple,
@@ -653,7 +654,9 @@ class Context(Generic[MODEL_T]):
                 )
             )
 
-    def write_event_to_stream(self, ev: Event | None, wait: bool = False):
+    def write_event_to_stream(
+        self, ev: Event | None, wait: bool = False
+    ) -> None | Coroutine[Any, Any, None]:
         """Enqueue an event for streaming to [WorkflowHandler]](workflows.handler.WorkflowHandler).
 
         Args:
@@ -688,10 +691,10 @@ class Context(Generic[MODEL_T]):
         # fire and forget
         if not wait:
             self._streaming_queue.put_nowait(ev)
-            return
+            return None
 
         # wait for listener
-        async def _wait_for_listener_processing():
+        async def _wait_for_listener_processing() -> None:
             completion_future: asyncio.Future = asyncio.Future()
             # wrap event with completion future
             self._streaming_queue.put_nowait((ev, completion_future))

--- a/src/workflows/handler.py
+++ b/src/workflows/handler.py
@@ -105,13 +105,14 @@ class WorkflowHandler(asyncio.Future[RunResultT]):
             raise WorkflowRuntimeError(msg)
 
         while True:
-            ev = await self.ctx.streaming_queue.get()
+            queue_item = await self.ctx.streaming_queue.get()
 
             # Check if wrapped with completion future
             completion_future = None
-            if isinstance(ev, tuple) and len(ev) == 2:
-                actual_event, completion_future = ev
-                ev = actual_event
+            if isinstance(queue_item, tuple):
+                ev, completion_future = queue_item
+            else:
+                ev = queue_item
 
             if isinstance(ev, InternalDispatchEvent) and not expose_internal:
                 if completion_future and not completion_future.done():


### PR DESCRIPTION
PR allowing event listeners to modify workflow events without race condition.

eg: 
```python
class MyEvent(Event):
    value: int


class MyWorkflow(Workflow):
    @step
    async def start(self, ctx: Context, _ev: StartEvent) -> StopEvent:
        event = MyEvent(value=1)

        await ctx.write_event_to_stream(event, wait=True)

        assert event.value == 100
        return StopEvent(result=event.value)


async def main():
    workflow = MyWorkflow(timeout=10, verbose=False)
    handler = workflow.run()

    async for event in handler.stream_events():
        if isinstance(event, MyEvent):
            time.sleep(3) # doing something here
            event.value = 100

    result = await handler
    assert result == 100
    print("✅ Test passed")
```
backward compatible