### PR TITLE
fix sqlite persistence: Properly serialize/deserialize result

### DIFF
--- a/src/workflows/server/sqlite/sqlite_workflow_store.py
+++ b/src/workflows/server/sqlite/sqlite_workflow_store.py
@@ -1,3 +1,4 @@
+from workflows.context import JsonSerializer
 from workflows.server.abstract_workflow_store import (
     AbstractWorkflowStore,
     HandlerQuery,
@@ -69,7 +70,9 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
                 handler.status,
                 handler.run_id,
                 handler.error,
-                json.dumps(handler.result) if handler.result is not None else None,
+                JsonSerializer().serialize(handler.result)
+                if handler.result is not None
+                else None,
                 handler.started_at.isoformat() if handler.started_at else None,
                 handler.updated_at.isoformat() if handler.updated_at else None,
                 handler.completed_at.isoformat() if handler.completed_at else None,


### PR DESCRIPTION
Fix for this bug in the server



```
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/starlette/routing.py", line 694, in lifespan
    async with self.lifespan_context(app) as maybe_state:
               ~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/Users/adrianlyjak/.local/share/uv/python/cpython-3.13.3-macos-aarch64-none/lib/python3.13/contextlib.py", line 221, in __aexit__
    await anext(self.gen)
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/fastapi/routing.py", line 210, in merged_lifespan
    async with original_context(app) as maybe_original_state:
               ~~~~~~~~~~~~~~~~^^^^^
  File "/Users/adrianlyjak/.local/share/uv/python/cpython-3.13.3-macos-aarch64-none/lib/python3.13/contextlib.py", line 221, in __aexit__
    await anext(self.gen)
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/llama_deploy/appserver/app.py", line 98, in lifespan
    async with server.contextmanager():
               ~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/adrianlyjak/.local/share/uv/python/cpython-3.13.3-macos-aarch64-none/lib/python3.13/contextlib.py", line 221, in __aexit__
    await anext(self.gen)
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/workflows/server/server.py", line 247, in contextmanager
    await self.stop()
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/workflows/server/server.py", line 253, in stop
    await asyncio.gather(
        *[self._close_handler(handler) for handler in list(self._handlers.values())]
    )
  File "/Users/adrianlyjak/dev/ws/extraction-review/.venv/lib/python3.13/site-packages/workflows/server/server.py", line 1374, in _close_handler
    await handler.task
TypeError: Object of type MetadataResponse is not JSON serializable

```