### PR TITLE
Improve stop event string representation

### DIFF
--- a/src/workflows/events.py
+++ b/src/workflows/events.py
@@ -198,6 +198,13 @@ class StopEvent(Event):
             data["result"] = self._result
         return data
 
+    def __repr__(self) -> str:
+        dict_items = {**self._data, **self.model_dump()}
+        # Format as key=value pairs
+        parts = [f"{k}={v!r}" for k, v in dict_items.items()]
+        dict_str = ", ".join(parts)
+        return f"{self.__class__.__name__}({dict_str})"
+
     def __str__(self) -> str:
         return str(self._result)
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -143,12 +143,23 @@ def test_custom_stop_event_serialization() -> None:
 
     serializer = JsonSerializer()
     serialized_ev = serializer.serialize(ev)
-    deseriazlied_ev = serializer.deserialize(serialized_ev)
+    deserialized_ev = serializer.deserialize(serialized_ev)
 
-    assert type(deseriazlied_ev).__name__ == type(ev).__name__
-    deseriazlied_ev = cast(
+    assert type(deserialized_ev).__name__ == type(ev).__name__
+    deserialized_ev = cast(
         CustomStopEvent,
-        deseriazlied_ev,
+        deserialized_ev,
     )
-    assert ev.foo == deseriazlied_ev.foo
-    assert ev.bar == deseriazlied_ev.bar
+    assert ev.foo == deserialized_ev.foo
+    assert ev.bar == deserialized_ev.bar
+
+
+def test_stop_event_repr() -> None:
+    ev = StopEvent(foo="foo", result=42)
+    assert repr(ev) == "StopEvent(foo='foo', result=42)"
+
+
+def test_custom_stop_event_repr_no_result() -> None:
+    ev = CustomStopEvent(foo="foo", bar=42)
+    rep = repr(ev)
+    assert rep == "CustomStopEvent(foo='foo', bar=42)"


### PR DESCRIPTION
Make StopEvent's easier to debug. Not sure there's a background to the `str(` conversion, but seems like at least the repr should show all the stop event's values and clarify what the class is:

before:
```
> StopEvent(foo="bar", result=42)
42
```

after:
```
> StopEvent(foo="bar", result=42)
StopEvent(foo='bar', result=42)
```