### PR TITLE
Fix openapi export

### DIFF
--- a/.github/workflows/publish_openapi.yml
+++ b/.github/workflows/publish_openapi.yml
@@ -36,12 +36,11 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "TARGET_TAG=${TAG}" >> "$GITHUB_ENV"
 
-      - name: Extract version information
-        id: version
+      - name: Compute release metadata
+        id: metadata
         run: >
-          uv run --package workflows-dev workflows-dev extract-tag-info
+          uv run --package workflows-dev workflows-dev compute-tag-metadata
           --tag "${{ env.TARGET_TAG }}"
-          --tag-prefix "llama-index-workflows@"
           --output "$GITHUB_OUTPUT"
 
       - name: Sync dependencies and build OpenAPI spec
@@ -57,21 +56,6 @@ jobs:
           files: packages/llama-index-workflows/openapi.json
           fail_on_unmatched_files: true
           append_body: false
-
-      - name: Detect change type automatically
-        id: detect_change
-        env:
-          GITHUB_REF: refs/tags/${{ env.TARGET_TAG }}
-        run: >
-          uv run --package workflows-dev workflows-dev detect-change-type
-          --tag-glob "llama-index-workflows@v*"
-          --tag-prefix "llama-index-workflows@"
-
-      - name: Resolve change metadata
-        id: metadata
-        run: |
-          echo "change_type=${{ steps.detect_change.outputs.change_type }}" >> "$GITHUB_OUTPUT"
-          echo "change_description=" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub App token
         id: app-token
@@ -91,7 +75,7 @@ jobs:
           repository: run-llama/llama-ui
           event-type: workflows-sdk-update
           client-payload: >-
-            {"version": "${{ steps.version.outputs.semver }}",
+            {"version": "${{ steps.metadata.outputs.semver }}",
              "openapi_url": "https://github.com/run-llama/workflows-py/releases/download/${{ env.TARGET_TAG }}/openapi.json",
              "change_type": "${{ steps.metadata.outputs.change_type }}",
              "change_description": "${{ steps.metadata.outputs.change_description }}"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,11 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+  "pytest-xdist>=3.8.0"
+]
+
 [project]
 name = "llama-agents-workspace"
 version = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1571,8 +1571,16 @@ dependencies = [
     { name = "tomli" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-xdist" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "tomli", specifier = ">=2.3.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-xdist", specifier = ">=3.8.0" }]
 
 [[package]]
 name = "llama-index-core"


### PR DESCRIPTION
The export was unnecessarily complicated with lots of params. The workflow also had an assumption that it would be run on a tag