### PR TITLE
Update llamactl disclaimers to beta

### DIFF
--- a/docs/src/content/docs/llamaagents/llamactl/agent-data-javascript.md
+++ b/docs/src/content/docs/llamaagents/llamactl/agent-data-javascript.md
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 Agent Data is a JSON store tied to a `deploymentName` and `collection`. Use the official JavaScript SDK with strong typing for CRUD, search, and aggregation.

--- a/docs/src/content/docs/llamaagents/llamactl/agent-data-overview.md
+++ b/docs/src/content/docs/llamaagents/llamactl/agent-data-overview.md
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 ### What is Agent Data?

--- a/docs/src/content/docs/llamaagents/llamactl/agent-data-python.md
+++ b/docs/src/content/docs/llamaagents/llamactl/agent-data-python.md
@@ -4,7 +4,7 @@ sidebar:
   order: 21
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 See the [Agent Data Overview](/python/llamaagents/llamactl/agent-data-overview) for concepts, constraints, and environment details.

--- a/docs/src/content/docs/llamaagents/llamactl/cd-with-github-actions.md
+++ b/docs/src/content/docs/llamaagents/llamactl/cd-with-github-actions.md
@@ -4,7 +4,7 @@ sidebar:
   order: 19
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 As described in the [Getting Started](/python/llamaagents/llamactl/getting-started) guide, deploying a LlamaAgent to LlamaCloud requires connecting it to a `git` source (specifically, GitHub).

--- a/docs/src/content/docs/llamaagents/llamactl/configuration-reference.md
+++ b/docs/src/content/docs/llamaagents/llamactl/configuration-reference.md
@@ -4,7 +4,7 @@ sidebar:
   order: 18
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 LlamaAgents reads configuration from your repository to run your app. The configuration is defined in your project's `pyproject.toml`.

--- a/docs/src/content/docs/llamaagents/llamactl/getting-started.md
+++ b/docs/src/content/docs/llamaagents/llamactl/getting-started.md
@@ -4,7 +4,7 @@ sidebar:
   order: 1
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 ## Getting Started with `llamactl`

--- a/docs/src/content/docs/llamaagents/llamactl/ui-build.md
+++ b/docs/src/content/docs/llamaagents/llamactl/ui-build.md
@@ -4,7 +4,7 @@ sidebar:
   order: 10
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 This page explains how to configure a custom frontend that builds and communicates with your LlamaAgents workflow server. If you've started from a template, you're good to go. Read on to learn more.

--- a/docs/src/content/docs/llamaagents/llamactl/ui-hooks.md
+++ b/docs/src/content/docs/llamaagents/llamactl/ui-hooks.md
@@ -5,7 +5,7 @@ sidebar:
 ---
 
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
 Our React library, `@llamaindex/ui`, is the recommended way to integrate your UI with a LlamaAgents workflow server and LlamaCloud. It comes pre-installed in any of our templates containing a UI. The library provides both React hooks for custom integrations and standard components.

--- a/docs/src/content/docs/llamaagents/llamactl/workflow-api.md
+++ b/docs/src/content/docs/llamaagents/llamactl/workflow-api.md
@@ -4,7 +4,7 @@ sidebar:
   order: 5
 ---
 :::caution
-Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud to share what you learn.
+Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 LlamaAgents runs your LlamaIndex workflows locally and in the cloud. Author your workflows, add minimal configuration, and `llamactl` wraps them in an application server that exposes them as HTTP APIs.
 


### PR DESCRIPTION
Update `llamactl` documentation disclaimers from alpha to beta preview and remove early sign-up links, as cloud deployments will be broadly available shortly

---
Linear Issue: [LI-4583](https://linear.app/llamaindex/issue/LI-4583/update-the-llamactl-disclaimer)

<a href="https://cursor.com/background-agent?bcId=bc-8c475943-5f34-47a9-986c-cd04a2174dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c475943-5f34-47a9-986c-cd04a2174dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

