### PR TITLE
fix: correct changeset package name typo and exclude docs from changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["docs"]
 }

--- a/.changeset/draw_recent_execution_mermaid.md
+++ b/.changeset/draw_recent_execution_mermaid.md
@@ -1,5 +1,5 @@
 ---
-"llama-index-utils-workflows": minor
+"llama-index-utils-workflow": minor
 ---
 
 Added new function draw_most_recent_execution_mermaid


### PR DESCRIPTION
- Fixed typo in changeset: llama-index-utils-workflows -> llama-index-utils-workflow
- Added docs to changeset ignore list to prevent it from appearing in version options