### PR TITLE
Automatically bump the uv.lock versions on version update

### DIFF
--- a/packages/workflows-dev/src/workflows_dev/changesets.py
+++ b/packages/workflows-dev/src/workflows_dev/changesets.py
@@ -73,14 +73,14 @@ def get_pnpm_workspace_packages() -> list[PackageJson]:
 
 def sync_package_version_with_pyproject(
     package_dir: Path, packages: dict[str, PackageJson], js_package_name: str
-) -> None:
+) -> bool:
     """Sync version from package.json to pyproject.toml.
 
     Returns True if pyproject was changed, else False.
     """
     pyproject_path = package_dir / "pyproject.toml"
     if not pyproject_path.exists():
-        return
+        return False
 
     package_version = packages[js_package_name].version
     toml_doc, py_doc = PyProjectContainer.parse(pyproject_path.read_text())
@@ -98,6 +98,8 @@ def sync_package_version_with_pyproject(
         click.echo(
             f"Updated {pyproject_path} version to {package_version} and synced dependency specs"
         )
+
+    return changed
 
 
 def _publishable_packages() -> Generator[Path, None, None]:


### PR DESCRIPTION
Modified sync_package_version_with_pyproject to return a boolean indicating whether the pyproject.toml was changed. After syncing all packages, if any pyproject.toml was updated, run uv sync in the root directory to update the lock file.

Otherwise, the first person to make updates after a version release gets a stray change to the lock file.

Would be good to later also enforce frozen lockfiles in ci checks to avoid lock drift