### PR TITLE
docs: fix streamed response handling in streaming events example

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/streaming.mdx
+++ b/docs/src/content/docs/llamaagents/workflows/streaming.mdx
@@ -63,7 +63,7 @@ class MyWorkflow(Workflow):
 
         return SecondEvent(
             second_output="Second step complete, full response attached",
-            response=response,
+            response=full_resp,
         )
 
     @step


### PR DESCRIPTION
## Description
Fixes the streaming events example to return the full accumulated LLM response instead of only the last streamed chunk. This makes the final workflow output consistent with the streamed progress shown during execution.