### PR TITLE
docs: add missing random imports in concurrency examples

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -12,6 +12,7 @@ To emit multiple events to trigger multiple steps, you can use `ctx.send_event()
 
 ```python
 import asyncio
+import random
 from workflows import Workflow, Context, step
 from workflows.events import Event, StartEvent, StopEvent
 
@@ -41,6 +42,7 @@ If you execute the previous example, you'll note that the workflow stops after w
 
 ```python
 import asyncio
+import random
 from workflows import Workflow, Context, step
 from workflows.events import Event, StartEvent, StopEvent
 


### PR DESCRIPTION
### Description

This PR fixes a missing import in the “Concurrent execution of workflows” documentation.

#### What changed

* Added `import random` to the Python code blocks that use `random.randint(...)` in the **Emitting multiple events** and **Collecting events** examples.

#### Why

The examples referenced `random.randint(...)` but didn’t import `random`, which causes a `NameError` when readers copy/paste and run the snippets.

#### Scope

* Documentation-only change (no runtime / library code impacted).
