### PR TITLE
docs: fix missing imports, typos and syntax errors in workflow docs 

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -12,6 +12,7 @@ To emit multiple events to trigger multiple steps, you can use `ctx.send_event()
 
 ```python
 import asyncio
+import random
 from workflows import Workflow, Context, step
 from workflows.events import Event, StartEvent, StopEvent
 
@@ -41,6 +42,7 @@ If you execute the previous example, you'll note that the workflow stops after w
 
 ```python
 import asyncio
+import random
 from workflows import Workflow, Context, step
 from workflows.events import Event, StartEvent, StopEvent
 

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -44,7 +44,7 @@ class JokeFlow(Workflow):
         # Build a query engine using the index and the llm from the start event
         query_engine = ev.an_index.as_query_engine(llm=ev.an_llm)
         topic = await query_engine.aquery(
-            f"What is the closest topic to {a_string_field}"
+            f"What is the closest topic to {ev.a_string_field}"
         )
         # Use the llm attached to the start event to instruct the model
         prompt = f"Write your best joke about {topic}."
@@ -98,7 +98,7 @@ class JokeFlow(Workflow):
 
         prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
         response = await self.llm.acomplete(prompt)
-        return MyStopEvent(response)
+        return MyStopEvent(critique=response)
 
     ...
 ```

--- a/docs/src/content/docs/llamaagents/workflows/deployment.md
+++ b/docs/src/content/docs/llamaagents/workflows/deployment.md
@@ -17,6 +17,7 @@ First, create a Python file (e.g., `my_server.py`):
 
 ```python
 # my_server.py
+import asyncio
 from workflows import Workflow, step
 from workflows.context import Context
 from workflows.events import Event, StartEvent, StopEvent
@@ -291,8 +292,8 @@ Assuming you are running the server example from above, we can use `WorkflowClie
 ```python
 from workflows.client import WorkflowClient
 
-async def main()
-  client = WorkflowClient(base_url="http://0.0.0.0:8080")
+async def main():
+    client = WorkflowClient(base_url="http://0.0.0.0:8080")
     workflows = await client.list_workflows()
     print("===== AVAILABLE WORKFLOWS ====")
     print(workflows)
@@ -357,14 +358,14 @@ await server.serve("0.0.0.0", "8080")
 You can now run the workflow and, when the human interaction is required, send the human response back:
 
 ```python
-from workflow.client import WorkflowClient
+from workflows.client import WorkflowClient
 
 client = WorkflowClient(base_url="http://0.0.0.0:8080")
 handler = await client.run_workflow_nowait("human")
 handler_id = handler.handler_id
 print(handler_id)
 async for event in client.get_workflow_events(handler_id=handler_id):
-    if "RequestEvent" == event.type
+    if "RequestEvent" == event.type:
         print(
             "Workflow is requiring human input:",
             event.value.get("prompt", ""),

--- a/docs/src/content/docs/llamaagents/workflows/drawing.md
+++ b/docs/src/content/docs/llamaagents/workflows/drawing.md
@@ -48,6 +48,7 @@ Setting up the server is straightforward:
 import asyncio
 from workflows import Workflow, step
 from workflows.events import StartEvent, StopEvent
+from workflows.server import WorkflowServer
 
 class MyWorkflow(Workflow):
     @step

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -73,7 +73,7 @@ class DurableWorkflow(Workflow):
         self.redis = r
 
     @step
-    def convert_documents(self, ev: StartEvent, ctx: Context) -> StopEvent:
+    async def convert_documents(self, ev: StartEvent, ctx: Context) -> StopEvent:
         # Get the workflow input
         document_ids = ev.ids
         # Get the list of processed documents from the state store
@@ -84,7 +84,7 @@ class DurableWorkflow(Workflow):
 		            continue
             convert()
             # Update the state store
-            converted_id.append(doc_id)
+            converted_ids.append(doc_id)
             await ctx.store.set("converted_ids", converted_ids)
             # Create a snapshot of the current context
             self.redis.hset("ctx", mapping=ctx.to_dict())
@@ -104,7 +104,7 @@ def get_redis_client(*args, **kwargs):
 
 class DurableWorkflow(Workflow):
     @step
-    def convert_documents(
+    async def convert_documents(
         self,
         ev: StartEvent,
         ctx: Context,
@@ -120,7 +120,7 @@ class DurableWorkflow(Workflow):
 		            continue
             convert()
             # Update the state store
-            converted_id.append(doc_id)
+            converted_ids.append(doc_id)
             await ctx.store.set("converted_ids", converted_ids)
             # Create a snapshot of the current context
             redis.hset("ctx", mapping=ctx.to_dict())

--- a/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
+++ b/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
@@ -9,7 +9,8 @@ Since workflows are so flexible, there are many possible ways to implement human
 The easiest way to implement a human-in-the-loop is to use the `InputRequiredEvent` and `HumanResponseEvent` events during event streaming.
 
 ```python
-from workflows.events import InputRequiredEvent, HumanResponseEvent
+from workflows import Workflow, step
+from workflows.events import StartEvent, StopEvent, InputRequiredEvent, HumanResponseEvent
 
 
 class HumanInTheLoopWorkflow(Workflow):
@@ -46,6 +47,8 @@ If needed, you can also subclass these two events to add custom payloads.
 You can break out of the event loop and resume later. This is useful when you want to pause the workflow to wait for a human response asynchronously (e.g., from a web request).
 
 ```python
+from workflows import Context
+
 handler = workflow.run()
 async for event in handler.stream_events():
     if isinstance(event, InputRequiredEvent):

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -29,7 +29,7 @@ There are cases where the state might be manipulated by multiple steps running a
 async def my_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
    # No other steps can access the state while the `with` block is running
    async with ctx.store.edit_state() as ctx_state:
-       if "count" not in state:
+       if "count" not in ctx_state:
            ctx_state["count"] = 0
        ctx_state["count"] += 1
    return StopEvent()
@@ -58,7 +58,7 @@ class CounterState(BaseModel):
 Then, simply annotate your workflow state with the state model:
 
 ```python
-from workflows import Workflow, step
+from workflows import Workflow, Context, step
 from workflows.events import (
     StartEvent,
     StopEvent,
@@ -97,6 +97,6 @@ result = await handler
 # ctx = Context.from_dict(workflow, ctx_dict)
 
 # continue with next run
-handler = w.run(ctx=ctx)
+handler = workflow.run(ctx=ctx)
 result = await handler
 ```

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -9,10 +9,13 @@ Resources are external dependencies you can inject into the steps of a workflow.
 As a simple example, look at `memory` from llama-index in the following workflow:
 
 ```python
+from typing import Annotated
+
+from workflows import Workflow, step
+from workflows.events import Event, StartEvent, StopEvent
 from workflows.resource import Resource
 from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import Memory
-from typing import Annotated
 
 
 def get_memory(*args, **kwargs):

--- a/docs/src/content/docs/llamaagents/workflows/retry_steps.md
+++ b/docs/src/content/docs/llamaagents/workflows/retry_steps.md
@@ -17,6 +17,8 @@ To set a policy for a specific step, all you have to do is passing a policy obje
 
 
 ```python
+from workflows import Workflow, Context, step
+from workflows.events import StartEvent, StopEvent
 from workflows.retry_policy import ConstantDelayRetryPolicy
 
 
@@ -46,6 +48,7 @@ For example, this is a retry policy that's excited about the weekend and only re
 
 ```python
 from datetime import datetime
+from typing import Optional
 
 
 class RetryOnFridayPolicy:

--- a/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
+++ b/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
@@ -9,6 +9,8 @@ Throughout these docs, we have been showing workflows defined as classes. Howeve
 First we create an empty class to hold the steps:
 
 ```python
+from workflows import Workflow
+
 class TestWorkflow(Workflow):
     pass
 ```
@@ -16,6 +18,9 @@ class TestWorkflow(Workflow):
 Now we can add steps to the workflow by defining functions and decorating them with the `@step()` decorator:
 
 ```python
+from workflows import step
+from workflows.events import StartEvent, StopEvent
+
 @step(workflow=TestWorkflow)
 def some_step(ev: StartEvent) -> StopEvent:
     return StopEvent()


### PR DESCRIPTION
- managing_state.md: Add missing Context import, fix state variable name typo (state -> ctx_state), fix workflow variable name (w -> workflow)
- concurrent_execution.md: Add missing random import in two code examples
- resources.md: Add missing imports for Workflow, step, Event, StartEvent, StopEvent
- human_in_the_loop.md: Add missing imports for Workflow, step, StartEvent, StopEvent and Context
- durable_workflows.md: Fix sync function to async (def -> async def) in two examples that use await, fix variable typo (converted_id -> converted_ids)
- customizing_entry_exit_points.md: Fix missing ev. prefix on a_string_field, add missing keyword argument (critique=) in MyStopEvent constructor
- retry_steps.md: Add missing imports for Workflow, Context, step, StartEvent, StopEvent and Optional
- unbound_functions.md: Add missing imports for Workflow, step, StartEvent, StopEvent
- drawing.md: Add missing WorkflowServer import
- deployment.md: Add missing asyncio import, fix missing colon after async def main(), fix typo in import path (workflow.client -> workflows.client), fix missing colon in if statement