### PR TITLE
Update debugger assets workflow to use llama-agents-server package

### DIFF
--- a/.github/workflows/update_debugger_assets.yml
+++ b/.github/workflows/update_debugger_assets.yml
@@ -52,7 +52,7 @@ jobs:
           CHANGESET_FILE=".changeset/update-debugger-assets.md"
           cat > "$CHANGESET_FILE" << 'EOF'
           ---
-          "llama-index-workflows": patch
+          "llama-agents-server": patch
           ---
 
           Update debugger assets
@@ -82,7 +82,7 @@ jobs:
             This PR updates the workflow debugger assets and creates a changeset for a patch version bump.
 
             ### Changes
-            - Updated `packages/llama-index-workflows/src/workflows/server/static/index.html`
+            - Updated `packages/llama-agents-server/src/llama_agents/server/static/index.html`
               - JavaScript: ${{ steps.payload.outputs.js_url }}
               - CSS: ${{ steps.payload.outputs.css_url }}
 

--- a/src/dev_cli/index_html.py
+++ b/src/dev_cli/index_html.py
@@ -19,9 +19,9 @@ def default_index_path() -> Path:
     return (
         Path(__file__).resolve().parents[2]
         / "packages"
-        / "llama-index-workflows"
+        / "llama-agents-server"
         / "src"
-        / "workflows"
+        / "llama_agents"
         / "server"
         / "static"
         / "index.html"


### PR DESCRIPTION
## Summary
This PR updates the debugger assets workflow and related configuration to reference the correct package name and directory structure. The changes reflect a migration from `llama-index-workflows` to `llama-agents-server` as the primary package for the server components.

## Key Changes
- Updated the changeset configuration in the GitHub Actions workflow to target `llama-agents-server` instead of `llama-index-workflows` for version bumping
- Corrected the package path in the workflow PR description to reflect the new directory structure
- Updated the `default_index_path()` function in `src/dev_cli/index_html.py` to point to the correct package location:
  - Changed package directory from `llama-index-workflows` to `llama-agents-server`
  - Updated the internal path from `workflows/server/static` to `llama_agents/server/static`

## Implementation Details
These changes ensure that the debugger assets update workflow correctly identifies and modifies the index.html file in the new `llama-agents-server` package structure, maintaining consistency across the development CLI tooling and CI/CD automation.

https://claude.ai/code/session_01QTCs9m11U3ubvmXmKAfg6A