### PR TITLE
Add Terraform configuration for PostHog Slack feedback notifications

### DIFF
--- a/infra/terraform-posthog/main.tf
+++ b/infra/terraform-posthog/main.tf
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+provider "posthog" {
+  api_key    = var.posthog_api_key
+  project_id = var.posthog_project_id
+}
+
+resource "posthog_hog_function" "slack_feedback_notification" {
+  name        = "Slack Feedback Notification"
+  description = "Posts to Slack whenever a feedback form is submitted"
+  type        = "destination"
+  enabled     = true
+  icon_url    = "https://raw.githubusercontent.com/PostHog/posthog/master/frontend/public/services/slack.png"
+
+  # Custom Hog code — based on PostHog's template-slack but uses a direct bot
+  # token instead of an OAuth integration, so it can be fully driven by vars.
+  hog = <<-EOT
+    let res := fetch('https://slack.com/api/chat.postMessage', {
+      'method': 'POST',
+      'headers': {
+        'Authorization': f'Bearer {inputs.slack_bot_token}',
+        'Content-Type': 'application/json'
+      },
+      'body': {
+        'channel': inputs.slack_channel,
+        'icon_emoji': ':mega:',
+        'username': 'PostHog Feedback',
+        'blocks': inputs.blocks,
+        'text': inputs.text
+      }
+    })
+
+    if (res.status >= 400) {
+      throw Error(f'Error from Slack API: {res.status}: {res.body}');
+    }
+    if (res.body.ok != true) {
+      throw Error(f'Error from Slack API: {res.body}');
+    }
+  EOT
+
+  inputs_json = jsonencode({
+    slack_bot_token = { value = var.slack_bot_token }
+    slack_channel   = { value = var.slack_channel }
+    text = {
+      value = "New feedback submitted by *{person.name}*"
+    }
+    blocks = {
+      value = [
+        {
+          type = "section"
+          text = {
+            type = "mrkdwn"
+            text = ":mega: *New Feedback Submitted*"
+          }
+        },
+        {
+          type = "section"
+          fields = [
+            { type = "mrkdwn", text = "*From:*\n{person.name}" },
+            { type = "mrkdwn", text = "*Event:*\n{event.event}" }
+          ]
+        },
+        {
+          type = "actions"
+          elements = [
+            {
+              type = "button"
+              text = {
+                type = "plain_text"
+                text = "View in PostHog"
+              }
+              url = "{person.url}"
+            }
+          ]
+        }
+      ]
+    }
+  })
+
+  filters_json = jsonencode({
+    events = [
+      {
+        id   = "survey sent"
+        name = "survey sent"
+        type = "events"
+      }
+    ]
+  })
+}

--- a/infra/terraform-posthog/variables.tf
+++ b/infra/terraform-posthog/variables.tf
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+variable "posthog_api_key" {
+  description = "PostHog personal API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "posthog_project_id" {
+  description = "PostHog project ID (environment) to target"
+  type        = string
+}
+
+variable "slack_bot_token" {
+  description = "Slack Bot OAuth token (xoxb-...) with chat:write scope"
+  type        = string
+  sensitive   = true
+}
+
+variable "slack_channel" {
+  description = "Slack channel ID to post feedback notifications to"
+  type        = string
+}

--- a/infra/terraform-posthog/versions.tf
+++ b/infra/terraform-posthog/versions.tf
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    posthog = {
+      source  = "PostHog/posthog"
+      version = "~> 1.0.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Terraform infrastructure-as-code to configure a PostHog Hog Function that automatically posts feedback form submissions to a Slack channel.

## Key Changes
- **main.tf**: Defines a `posthog_hog_function` resource that creates a "Slack Feedback Notification" destination function
  - Implements custom Hog code to fetch and post messages to Slack's `chat.postMessage` API
  - Configures message formatting with blocks including feedback submitter name, event type, and a link to view the person in PostHog
  - Filters to trigger only on "survey sent" events
  - Includes error handling for Slack API failures

- **variables.tf**: Declares required input variables
  - `posthog_api_key`: PostHog personal API key (sensitive)
  - `posthog_project_id`: Target PostHog project/environment
  - `slack_bot_token`: Slack Bot OAuth token with chat:write scope (sensitive)
  - `slack_channel`: Target Slack channel ID

- **versions.tf**: Specifies Terraform and provider requirements
  - Requires Terraform >= 1.0
  - Requires PostHog provider ~> 1.0.4

## Notable Implementation Details
- Uses a direct Slack bot token approach rather than OAuth integration, allowing full configuration via Terraform variables
- Implements proper error handling with status code and response body validation
- Leverages PostHog's templating syntax (e.g., `{person.name}`, `{event.event}`) for dynamic message content
- Includes MIT license headers consistent with project standards

https://claude.ai/code/session_0182eJNyfkXhHPMyUhdaA8Jh