### PR TITLE
Add write lock to serialize event stream writes in ServerRuntime

### DIFF
--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/server_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/server_runtime.py
@@ -74,6 +74,7 @@ class _ServerInternalRunAdapter(BaseInternalRunAdapterDecorator):
         self._store = runtime._store
         self._state_type = state_type
         self._state_store: StateStore[Any] | None = None
+        self._write_lock = asyncio.Lock()
 
     @override
     def get_state_store(self) -> StateStore[Any]:
@@ -92,38 +93,43 @@ class _ServerInternalRunAdapter(BaseInternalRunAdapterDecorator):
 
     @override
     async def write_to_event_stream(self, event: Event) -> None:
-        """Record events to the workflow store, skipping duplicates on replay."""
-        replaying = self.is_replaying()
+        """Record events to the workflow store, skipping duplicates on replay.
 
-        if not replaying:
-            if isinstance(event, WorkflowFailedEvent):
-                await self._runtime._handle_status_update(
-                    run_id=self.run_id,
-                    status="failed",
-                    error=event.exception_message,
-                )
-            elif isinstance(event, WorkflowTimedOutEvent):
-                await self._runtime._handle_status_update(
-                    run_id=self.run_id,
-                    status="failed",
-                    error=f"Workflow timed out after {event.timeout}s",
-                )
-            elif isinstance(event, WorkflowCancelledEvent):
-                await self._runtime._handle_status_update(
-                    run_id=self.run_id, status="cancelled"
-                )
-            elif isinstance(event, StopEvent):
-                await self._runtime._handle_status_update(
-                    run_id=self.run_id,
-                    status="completed",
-                    result=event,
-                )
+        Uses a lock to serialize writes, ensuring events are stored in the
+        order they were emitted even when called from concurrent tasks.
+        """
+        async with self._write_lock:
+            replaying = self.is_replaying()
 
-            envelope = EventEnvelopeWithMetadata.from_event(event)
-            await self._store.append_event(self.run_id, envelope)
+            if not replaying:
+                if isinstance(event, WorkflowFailedEvent):
+                    await self._runtime._handle_status_update(
+                        run_id=self.run_id,
+                        status="failed",
+                        error=event.exception_message,
+                    )
+                elif isinstance(event, WorkflowTimedOutEvent):
+                    await self._runtime._handle_status_update(
+                        run_id=self.run_id,
+                        status="failed",
+                        error=f"Workflow timed out after {event.timeout}s",
+                    )
+                elif isinstance(event, WorkflowCancelledEvent):
+                    await self._runtime._handle_status_update(
+                        run_id=self.run_id, status="cancelled"
+                    )
+                elif isinstance(event, StopEvent):
+                    await self._runtime._handle_status_update(
+                        run_id=self.run_id,
+                        status="completed",
+                        result=event,
+                    )
 
-        # Always forward to inner adapter (e.g. idle detection, DBOS stream)
-        await super().write_to_event_stream(event)
+                envelope = EventEnvelopeWithMetadata.from_event(event)
+                await self._store.append_event(self.run_id, envelope)
+
+            # Always forward to inner adapter (e.g. idle detection, DBOS stream)
+            await super().write_to_event_stream(event)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This change adds thread-safe serialization of event writes in the `ServerRuntime.write_to_event_stream()` method by introducing an `asyncio.Lock`. This ensures that events are stored in the order they were emitted, even when called concurrently from multiple tasks.

## Key Changes
- Added `_write_lock: asyncio.Lock()` instance variable to `ServerRuntime.__init__()`
- Wrapped the entire `write_to_event_stream()` method body with `async with self._write_lock:` to serialize concurrent write operations
- Updated docstring to document the locking behavior

## Implementation Details
The lock is acquired before checking replay status and held throughout the entire write operation, including:
- Status update handling for workflow events (failed, timed out, cancelled, completed)
- Event envelope creation and storage via `self._store.append_event()`
- Forwarding to the inner adapter

This prevents race conditions where concurrent event emissions could result in out-of-order storage or interleaved writes to the event store.