### PR TITLE
chore: use app token in bump_llama_index_core workflow

### DIFF
--- a/.github/workflows/bump_llama_index_core.yml
+++ b/.github/workflows/bump_llama_index_core.yml
@@ -16,9 +16,17 @@ jobs:
 
       - run: uv lock --upgrade-package llama-index-core
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: bump llama-index-core"
           branch: bump-llama-index-core
           delete-branch: true


### PR DESCRIPTION
Use the CI bot app token instead of the default GITHUB_TOKEN when creating PRs so that subsequent CI workflows (lint, test) actually trigger on the created PR.