### PR TITLE
Update GitHub workflow repository references to llama-agents

### DIFF
--- a/.github/workflows/bump_llama_index_core.yml
+++ b/.github/workflows/bump_llama_index_core.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-dependency:
-    if: github.repository == 'run-llama/workflows-py'
+    if: github.repository == 'run-llama/llama-agents'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish_changesets.yml
+++ b/.github/workflows/publish_changesets.yml
@@ -30,7 +30,7 @@ jobs:
     name: Plan release
     runs-on: ubuntu-latest
     environment: release
-    if: github.repository == 'run-llama/workflows-py' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
+    if: github.repository == 'run-llama/llama-agents' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
     outputs:
       has_work: ${{ steps.plan.outputs.has_work }}
       pypi: ${{ steps.plan.outputs.pypi }}

--- a/.github/workflows/publish_openapi.yml
+++ b/.github/workflows/publish_openapi.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   publish-openapi:
-    if: github.repository == 'run-llama/workflows-py'
+    if: github.repository == 'run-llama/llama-agents'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sync-docs:
-    if: github.repository == 'run-llama/workflows-py'
+    if: github.repository == 'run-llama/llama-agents'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
   coveralls-finish:
     needs: [test, test-docker]
     runs-on: ubuntu-latest
-    if: github.repository == 'run-llama/workflows-py'
+    if: github.repository == 'run-llama/llama-agents'
     steps:
       - name: Finalize Coveralls parallel jobs
         continue-on-error: true

--- a/.github/workflows/update_debugger_assets.yml
+++ b/.github/workflows/update_debugger_assets.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   update-assets:
-    if: github.repository == 'run-llama/workflows-py'
+    if: github.repository == 'run-llama/llama-agents'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Updated all GitHub Actions workflow files to reference the correct repository name `run-llama/llama-agents` instead of the incorrect `run-llama/workflows-py`.

## Changes
- **bump_llama_index_core.yml**: Updated repository check in `bump-dependency` job
- **publish_changesets.yml**: Updated repository check in `plan-release` job
- **publish_openapi.yml**: Updated repository check in `publish-openapi` job
- **sync-docs.yml**: Updated repository check in `sync-docs` job
- **test.yml**: Updated repository check in `coveralls-finish` job
- **update_debugger_assets.yml**: Updated repository check in `update-assets` job

## Details
All workflow files contained conditional checks (`if: github.repository == ...`) that were pointing to an incorrect repository name. These have been corrected to ensure workflows only execute when running in the actual `run-llama/llama-agents` repository, preventing unintended execution in forks or other repositories.

https://claude.ai/code/session_01M1jqrSFSod9h2eUA287Etn