### PR TITLE
Update repository references from workflows-py to llama-agents

### DIFF
--- a/.github/workflows/publish_openapi.yml
+++ b/.github/workflows/publish_openapi.yml
@@ -76,6 +76,6 @@ jobs:
           event-type: workflows-sdk-update
           client-payload: >-
             {"version": "${{ steps.metadata.outputs.semver }}",
-             "openapi_url": "https://github.com/run-llama/workflows-py/releases/download/${{ env.TARGET_TAG }}/openapi.json",
+             "openapi_url": "https://github.com/run-llama/llama-agents/releases/download/${{ env.TARGET_TAG }}/openapi.json",
              "change_type": "${{ steps.metadata.outputs.change_type }}",
              "change_description": "${{ steps.metadata.outputs.change_description }}"}

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -42,5 +42,5 @@ jobs:
           fi
 
           SOURCE_SHA="${GITHUB_SHA::8}"
-          git commit -m "sync: workflows-py docs from run-llama/workflows-py@${SOURCE_SHA}"
+          git commit -m "sync: llama-agents docs from run-llama/llama-agents@${SOURCE_SHA}"
           git push

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Start as a function you call from a script. Wrap it in a server when you need an
 
 And because it's a library at its core, the same workflow code drops into wherever the work has to actually run: a notebook for prototyping, a FastAPI app for your product, or a customer's locked-down environment when their documents can't leave it.
 
-For more ideas of what it can do, take a look at [the examples](https://github.com/run-llama/workflows-py/tree/main/examples).
+For more ideas of what it can do, take a look at [the examples](https://github.com/run-llama/llama-agents/tree/main/examples).
 
 ## Use it as a library
 
@@ -40,7 +40,7 @@ class HelloWorkflow(Workflow):
         return StopEvent(result=f"Hello, {ev.name}")
 ```
 
-See the [`llama-index-workflows` package](https://github.com/run-llama/workflows-py/tree/main/packages/llama-index-workflows) for more details.
+See the [`llama-index-workflows` package](https://github.com/run-llama/llama-agents/tree/main/packages/llama-index-workflows) for more details.
 
 ## Mount it inside an app you already have
 
@@ -53,7 +53,7 @@ server = WorkflowServer()
 server.add_workflow("greet", HelloWorkflow())
 ```
 
-See the [`llama-agents-server` package](https://github.com/run-llama/workflows-py/tree/main/packages/llama-agents-server) and the [`llama-agents-client` package](https://github.com/run-llama/workflows-py/tree/main/packages/llama-agents-client) for more details.
+See the [`llama-agents-server` package](https://github.com/run-llama/llama-agents/tree/main/packages/llama-agents-server) and the [`llama-agents-client` package](https://github.com/run-llama/llama-agents/tree/main/packages/llama-agents-client) for more details.
 
 ## Or ship it as a deployable agent
 
@@ -66,7 +66,7 @@ llamactl serve
 llamactl deployments create
 ```
 
-See the [`llamactl` package](https://github.com/run-llama/workflows-py/tree/main/packages/llamactl) for more details.
+See the [`llamactl` package](https://github.com/run-llama/llama-agents/tree/main/packages/llamactl) for more details.
 
 ## Works with [LlamaParse](https://developers.llamaindex.ai/python/cloud/)
 

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -6,7 +6,7 @@ title: Observability
 
 Observability is key for debugging workflows. Beyond just adding `print()` statements, `workflows` ship with an extensive instrumentation system that tracks the input and output of every workflow step.
 
-Furthermore, you can leverage this instrumentation system to add observability to any function outside of workflow steps! More in-depth examples for all of this information can be found in the [examples folder for observability](https://github.com/run-llama/workflows-py/tree/main/examples/observability).
+Furthermore, you can leverage this instrumentation system to add observability to any function outside of workflow steps! More in-depth examples for all of this information can be found in the [examples folder for observability](https://github.com/run-llama/llama-agents/tree/main/examples/observability).
 
 ## OpenTelemetry Integration
 
@@ -47,13 +47,13 @@ Workflows integrate seamlessly with popular observability platforms:
 
 [Arize Phoenix](https://docs.arize.com/phoenix/integrations/frameworks/llamaindex/llamaindex-workflows-tracing) provides real-time tracing and visualization for your workflows.
 
-You can read more in the [example notebook.](https://github.com/run-llama/workflows-py/blob/main/examples/observability/workflows_observablitiy_arize_phoenix.ipynb)
+You can read more in the [example notebook.](https://github.com/run-llama/llama-agents/blob/main/examples/observability/workflows_observablitiy_arize_phoenix.ipynb)
 
 ### Langfuse
 
 [Langfuse](https://github.com/langfuse/langfuse) directly integrates with the instrumentation system that ships with workflows.
 
-You can read more in the [example notebook.](https://github.com/run-llama/workflows-py/blob/main/examples/observability/workflows_observablitiy_langfuse.ipynb)
+You can read more in the [example notebook.](https://github.com/run-llama/llama-agents/blob/main/examples/observability/workflows_observablitiy_langfuse.ipynb)
 
 ### Opik
 
@@ -89,4 +89,4 @@ def example_fn(data: str) -> None:
 
 When you call instrumented functions, all spans and events are automatically captured by any configured tracing backend.
 
-See complete examples in the [examples/observability](https://github.com/run-llama/workflows-py/tree/main/examples/observability) directory.
+See complete examples in the [examples/observability](https://github.com/run-llama/llama-agents/tree/main/examples/observability) directory.

--- a/examples/observability/workflows_observability_pt1.ipynb
+++ b/examples/observability/workflows_observability_pt1.ipynb
@@ -31,7 +31,7 @@
     "In this notebook, we will go through an example of how to use instrumentation natively implemented in `llama-index` (combined with OpenTelemetry) to define costum span and events within your code. Before we get started:\n",
     "\n",
     "\n",
-    "⭐ Don'f forget to star the `llama-index-workflows` [GitHub repo](https://github.com/run-llama/workflows-py)\n",
+    "⭐ Don'f forget to star the `llama-index-workflows` [GitHub repo](https://github.com/run-llama/llama-agents)\n",
     "\n",
     "🦙☁ Register to [LlamaCloud](https://cloud.llamaindex.ai) not to miss out on all our awesome products\n",
     "\n",

--- a/examples/observability/workflows_observability_pt2.ipynb
+++ b/examples/observability/workflows_observability_pt2.ipynb
@@ -13,7 +13,7 @@
     "In this notebook, we will go through a more complex and complete example of how to use instrumentation natively implemented in `llama-index` (combined with OpenTelemetry) to define costum span and events within your code. Before we get started:\n",
     "\n",
     "\n",
-    "⭐ Don'f forget to star the `llama-index-workflows` [GitHub repo](https://github.com/run-llama/workflows-py)\n",
+    "⭐ Don'f forget to star the `llama-index-workflows` [GitHub repo](https://github.com/run-llama/llama-agents)\n",
     "\n",
     "🦙☁ Register to [LlamaCloud](https://cloud.llamaindex.ai) not to miss out on all our awesome products\n",
     "\n",
@@ -1791,7 +1791,7 @@
     "id": "-3T7L45DYmzy"
    },
    "source": [
-    "And this is all for our advanced observability demo: let us know if you have any more questions and don't forget to star the [LlamaIndex workflows repo](https://github.com/run-llama/workflows-py)🦙🚀"
+    "And this is all for our advanced observability demo: let us know if you have any more questions and don't forget to star the [LlamaIndex workflows repo](https://github.com/run-llama/llama-agents)🦙🚀"
    ]
   }
  ],

--- a/examples/state_management_with_vector_databases.ipynb
+++ b/examples/state_management_with_vector_databases.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "Workflows are notoriously event-driven code solutions, but it is more and more crucial, for production-grade applications, that they also have write and read access to a global state where they can store and fetch data that are relevant to their run.\n",
     "\n",
-    "[llama-index-workflows](https://github.com/run-llama/workflows-py) offer a perfect solution for customized, asynchronous and lockable [state management](https://docs.llamaindex.ai/en/latest/module_guides/workflow/#adding-typed-state), but the state lacks persistency across different sessions - and this is exactly where databases, and especially vector databases, enter the game.\n",
+    "[llama-index-workflows](https://github.com/run-llama/llama-agents) offer a perfect solution for customized, asynchronous and lockable [state management](https://docs.llamaindex.ai/en/latest/module_guides/workflow/#adding-typed-state), but the state lacks persistency across different sessions - and this is exactly where databases, and especially vector databases, enter the game.\n",
     "\n",
     "With a database, you can take snapshots of the workflow state at the end of a run and store them into it, to retrieve them in later runs and inform the behavior of the workflow itself.\n",
     "\n",


### PR DESCRIPTION
## Summary
This PR updates all repository references throughout the codebase from the old `workflows-py` repository to the new `llama-agents` repository. This reflects a repository rename/migration for the LlamaIndex workflows project.

## Key Changes
- Updated GitHub repository URLs in README.md from `run-llama/workflows-py` to `run-llama/llama-agents` across all package references (llama-index-workflows, llama-agents-server, llama-agents-client, llamactl)
- Updated documentation links in `docs/src/content/docs/llamaagents/workflows/observability.md` to point to the new repository
- Updated example notebook references in `examples/observability/workflows_observability_pt1.ipynb` and `examples/observability/workflows_observability_pt2.ipynb`
- Updated example notebook reference in `examples/state_management_with_vector_databases.ipynb`
- Updated GitHub Actions workflow files:
  - `.github/workflows/publish_openapi.yml`: Updated OpenAPI release URL
  - `.github/workflows/sync-docs.yml`: Updated commit message and source repository reference

## Implementation Details
All changes are straightforward URL and reference updates with no functional code modifications. The updates ensure that users and CI/CD pipelines reference the correct repository location for the llama-agents project.

https://claude.ai/code/session_012HRiMW75jYJufcD4eJNqM2