### PR TITLE
fix(docs-sync): resolve developer-hub path to absolute before cd

### DIFF
--- a/scripts/sync-docs-to-developer-hub.sh
+++ b/scripts/sync-docs-to-developer-hub.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCS_REPO="${1:?Usage: $0 /path/to/developer-hub-repo}"
+DOCS_REPO_ARG="${1:?Usage: $0 /path/to/developer-hub-repo}"
+# Resolve to an absolute path up front: later commands `cd` before using this,
+# so a relative path would resolve against the wrong directory.
+mkdir -p "$DOCS_REPO_ARG"
+DOCS_REPO="$(cd "$DOCS_REPO_ARG" && pwd)"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 


### PR DESCRIPTION
The sync-docs-to-developer-hub.sh script accepts the developer-hub repo path as its first argument. The CI workflow passes it as a relative path (`developer-hub`) pointing to the checkout at the repo root. The markdown rsync step ran before any `cd`, so the relative path resolved correctly, but the mkdocs build step `cd`s into docs/api_docs first and then uses the still-relative `$DOCS_REPO/api-reference/python/workflows` as its output directory. mkdocs consequently wrote the built API reference to `docs/api_docs/developer-hub/...` inside the source repo instead of into the actual developer-hub checkout, so the subsequent `git add api-reference/python/workflows/` found nothing to commit and the API reference was never synced downstream.

Resolve $DOCS_REPO to an absolute path once up front so later `cd`s do not change its meaning.