### PR TITLE
fix(ci): use github-api commitMode for tag creation

### DIFF
--- a/.github/workflows/publish_changesets.yml
+++ b/.github/workflows/publish_changesets.yml
@@ -262,6 +262,7 @@ jobs:
         with:
           publish: pnpm exec changeset tag
           setupGitUser: false
+          commitMode: github-api
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Follow-up to #541. The new Finalize step used `changesets/action` in publish mode but without `commitMode: github-api`, so it fell into the default `git-cli` `pushTag` path:

```
/usr/bin/git push origin llama-agents@0.10.12
error: src refspec llama-agents@0.10.12 does not match any
```

The tag is created by the publish subprocess (`pnpm exec changeset tag`) but the subsequent `git push` in the action's `Git` class cannot find the ref. Switching to `commitMode: github-api` makes the action create tag refs through `octokit.rest.git.createRef` against `github.context.sha` instead — which is also what the Plan job already uses.