### PR TITLE
feat: PUBLIC_* env overlay for UI builds + network policy knobs

### DIFF
--- a/.changeset/network-policy-knobs.md
+++ b/.changeset/network-policy-knobs.md
@@ -1,5 +1,5 @@
 ---
-"llama-agents": minor
+"llama-agents": patch
 ---
 
-Network policy gains `extraEgressRules`, configurable DNS selectors, and `blockPrivateRanges` toggle for reaching in-cluster services without disabling the policy.
+New network policy values: `extraEgressRules`, configurable DNS selectors, and `blockPrivateRanges` toggle for reaching in-cluster services without disabling the policy.

--- a/.changeset/network-policy-knobs.md
+++ b/.changeset/network-policy-knobs.md
@@ -1,0 +1,5 @@
+---
+"llama-agents": minor
+---
+
+Network policy gains `extraEgressRules`, configurable DNS selectors, and `blockPrivateRanges` toggle for reaching in-cluster services without disabling the policy.

--- a/.changeset/public-env-overlay.md
+++ b/.changeset/public-env-overlay.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-appserver": minor
+"llamactl": patch
+---
+
+`PUBLIC_*` env var overlay for UI builds: `PUBLIC_X` overrides `X` in the build env so backend and frontend can use different URLs for the same service. Removes dead `VITE_`/`NEXT_PUBLIC_` injection from `llamactl serve`. Helm network policy gains `extraEgressRules`, DNS selector overrides, and `blockPrivateRanges` toggle.

--- a/charts/llama-agents/README.md
+++ b/charts/llama-agents/README.md
@@ -199,6 +199,10 @@ install requires draining and recreating `LlamaDeployment` CRs.
 |-----|------|---------|-------------|
 | networkPolicy.enabled | bool | `true` | Enable egress NetworkPolicy for operator-managed pods |
 | networkPolicy.extraMatchExpressions | list | `[]` | Additional pod selector matchExpressions |
+| networkPolicy.extraEgressRules | list | `[]` | Extra egress rules appended to the NetworkPolicy |
+| networkPolicy.blockPrivateRanges | bool | `true` | Block private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) in internet egress rule |
+| networkPolicy.dns.namespaceSelector | object | `{"kubernetes.io/metadata.name":"kube-system"}` | Namespace selector for DNS pods. Defaults to kube-system |
+| networkPolicy.dns.podSelector | object | `{"k8s-app":"kube-dns"}` | Pod selector for DNS pods. Defaults to kube-dns |
 
 ## Uninstalling
 

--- a/charts/llama-agents/templates/networkpolicy.yaml
+++ b/charts/llama-agents/templates/networkpolicy.yaml
@@ -35,23 +35,28 @@ spec:
   - to:
     - namespaceSelector:
         matchLabels:
-          kubernetes.io/metadata.name: kube-system
+          {{- toYaml .Values.networkPolicy.dns.namespaceSelector | nindent 10 }}
       podSelector:
         matchLabels:
-          k8s-app: kube-dns
+          {{- toYaml .Values.networkPolicy.dns.podSelector | nindent 10 }}
     ports:
     - protocol: UDP
       port: 53
     - protocol: TCP
       port: 53
-  # Allow Internet access but block private ranges and IMDS
+  # Allow Internet access
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
+        {{- if .Values.networkPolicy.blockPrivateRanges }}
         except:
         - 169.254.169.254/32  # AWS IMDS
         - 10.0.0.0/8          # Private ranges
         - 172.16.0.0/12
         - 192.168.0.0/16
         - 100.64.0.0/10       # Carrier-grade NAT
+        {{- end }}
+  {{- with .Values.networkPolicy.extraEgressRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/charts/llama-agents/values.yaml
+++ b/charts/llama-agents/values.yaml
@@ -286,3 +286,18 @@ networkPolicy:
   # -- Additional pod selector matchExpressions
   # @section -- Network Policy
   extraMatchExpressions: []
+  # -- Extra egress rules appended to the NetworkPolicy
+  # @section -- Network Policy
+  extraEgressRules: []
+  # -- Block private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) in internet egress rule
+  # @section -- Network Policy
+  blockPrivateRanges: true
+  dns:
+    # -- Namespace selector for DNS pods. Defaults to kube-system
+    # @section -- Network Policy
+    namespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    # -- Pod selector for DNS pods. Defaults to kube-dns
+    # @section -- Network Policy
+    podSelector:
+      k8s-app: kube-dns

--- a/docs/src/content/docs/llamaagents/llamactl/ui-build.md
+++ b/docs/src/content/docs/llamaagents/llamactl/ui-build.md
@@ -136,6 +136,18 @@ export default function Logo() {
 }
 ```
 
+## `PUBLIC_*` env var overrides
+
+Set `PUBLIC_X` to override `X` in the UI build env only. The backend keeps the original value. `PUBLIC_*` keys are stripped from the build environment.
+
+```yaml
+env:
+  API_URL: "http://internal.svc:8000"
+  PUBLIC_API_URL: "https://api.example.com"  # UI build sees API_URL=https://api.example.com
+```
+
+Your vite/next config can then map the overridden value into framework-specific vars (e.g. `VITE_API_URL` via a `define` block) as usual.
+
 ## Configure the UI output directory
 
 Your UI must output static assets that the platform can locate. Configure `ui.directory` and `ui.build_output_dir` as described in the [Deployment Config Reference](/python/llamaagents/llamactl/configuration-reference#uiconfig-fields). Default: `${ui.directory}/dist`.

--- a/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
+++ b/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
@@ -533,6 +533,13 @@ def _ui_env(config: DeploymentConfig, settings: ApiserverSettings) -> dict[str, 
     if config.ui is not None:
         env["PORT"] = str(settings.proxy_ui_port)
     env["LLAMA_DEPLOY_SERVER_PORT"] = str(settings.port)
+    # Apply PUBLIC_* overlays: PUBLIC_X overrides X in the UI build env
+    public_prefix = "PUBLIC_"
+    public_keys = [k for k in env if k.startswith(public_prefix)]
+    for key in public_keys:
+        base_key = key[len(public_prefix) :]
+        env[base_key] = env[key]
+        del env[key]
     return env
 
 

--- a/packages/llama-agents-appserver/tests/test_workflow_loader.py
+++ b/packages/llama-agents-appserver/tests/test_workflow_loader.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 from llama_agents.appserver.settings import ApiserverSettings
 from llama_agents.appserver.workflow_loader import (
+    _ui_env,
     build_ui,
     load_environment_variables,
     load_workflows,
@@ -74,3 +75,32 @@ def test_build_ui_sets_env_and_calls_pnpm(
         assert env["LLAMA_DEPLOY_DEPLOYMENT_NAME"] == "n"
         assert env["LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH"] == "/deployments/n/ui"
         assert env["PORT"] == "4503"
+
+
+def test_ui_env_public_overrides_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_CLOUD_BASE_URL", "https://original.example.com")
+    monkeypatch.setenv("PUBLIC_LLAMA_CLOUD_BASE_URL", "https://public.example.com")
+    cfg = DeploymentConfig(name="n", ui=UIConfig(directory="ui"))
+    settings = ApiserverSettings()
+    env = _ui_env(cfg, settings)
+    assert env["LLAMA_CLOUD_BASE_URL"] == "https://public.example.com"
+    assert "PUBLIC_LLAMA_CLOUD_BASE_URL" not in env
+
+
+def test_ui_env_public_without_base_creates_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FOO", raising=False)
+    monkeypatch.setenv("PUBLIC_FOO", "bar")
+    cfg = DeploymentConfig(name="n", ui=UIConfig(directory="ui"))
+    settings = ApiserverSettings()
+    env = _ui_env(cfg, settings)
+    assert env["FOO"] == "bar"
+    assert "PUBLIC_FOO" not in env
+
+
+def test_ui_env_no_public_leaves_base_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_CLOUD_BASE_URL", "https://original.example.com")
+    monkeypatch.delenv("PUBLIC_LLAMA_CLOUD_BASE_URL", raising=False)
+    cfg = DeploymentConfig(name="n", ui=UIConfig(directory="ui"))
+    settings = ApiserverSettings()
+    env = _ui_env(cfg, settings)
+    assert env["LLAMA_CLOUD_BASE_URL"] == "https://original.example.com"

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -186,10 +186,6 @@ def _set_env_vars_from_env(env_vars: dict[str, str]) -> None:
 def _set_env_vars(key: str, url: str) -> None:
     os.environ["LLAMA_CLOUD_API_KEY"] = key
     os.environ["LLAMA_CLOUD_BASE_URL"] = url
-    # kludge for common web servers to inject local auth key
-    for prefix in ["VITE_", "NEXT_PUBLIC_"]:
-        os.environ[f"{prefix}LLAMA_CLOUD_API_KEY"] = key
-        os.environ[f"{prefix}LLAMA_CLOUD_BASE_URL"] = url
 
 
 def _set_project_id_from_env(env_vars: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary

Adds `PUBLIC_*` env var overlays so the backend and frontend can use different URLs for the same service, e.g. an internal cluster address for the backend and a public URL baked into the frontend build.

- `_ui_env()` applies `PUBLIC_X` → `X` overlays, strips the `PUBLIC_` keys from the build env
- Helm network policy gains `extraEgressRules`, configurable DNS selectors, and a `blockPrivateRanges` toggle. Enough to allow egress to in-cluster services without disabling the policy entirely
- Removes dead `VITE_`/`NEXT_PUBLIC_` injection from `llamactl serve` (templates already read the unprefixed vars via `define` blocks)