### PR TITLE
docs: agent_data overview uses create() not agent_data()

### DIFF
--- a/docs/src/content/docs/llamaagents/cloud/agent-data-overview.md
+++ b/docs/src/content/docs/llamaagents/cloud/agent-data-overview.md
@@ -86,7 +86,7 @@ extracted = ExtractedData.from_extract_job(
     schema=Invoice,
 )
 
-await client.beta.agent_data.agent_data(
+await client.beta.agent_data.create(
     data=extracted.model_dump(),
     deployment_name=deployment_name,
     collection="invoices",


### PR DESCRIPTION
- SDK method was renamed from `agent_data` to `create`. Old name is a deprecated alias in the upcoming SDK release.
- Update the example in `agent-data-overview.md` to use `create()`.